### PR TITLE
Refactor bot architecture into facade + GatewayRuntime + APIClient

### DIFF
--- a/vaidcord-py/README.md
+++ b/vaidcord-py/README.md
@@ -52,6 +52,8 @@ uv add "vaidcord[postgres]"
 await dp.start_polling(bot)
 await dp.start_websocket(bot)
 await dp.start_webhook(bot, drop_pending_updates=True)
+await dp.start_polling_many([bot_a, bot_b])
+await dp.start_webhook_many([bot_a, bot_b], drop_pending_updates=True)
 ```
 
 `Dispatcher()` auto-registers FSM middleware. If you do not pass storage, it uses in-memory storage by default.

--- a/vaidcord-py/README.md
+++ b/vaidcord-py/README.md
@@ -29,7 +29,9 @@ uv add "vaidcord[postgres]"
 
 ## Mental model
 
-- `Bot` owns transport and Discord API calls.
+- `Bot` is a facade/orchestrator that wires runtime + REST client + routers.
+- `GatewayRuntime` owns websocket lifecycle (`connect/identify/heartbeat/dispatch loop`).
+- `APIClient` owns Discord REST calls and delegates HTTP details to `HTTPClient`.
 - `Dispatcher` is the root router and runtime coordinator.
 - `Router` groups features into reusable modules.
 - `Middleware` wraps event handling.

--- a/vaidcord-py/docs/APPLICATION_API.md
+++ b/vaidcord-py/docs/APPLICATION_API.md
@@ -7,6 +7,7 @@ VaidCord exposes Discord application resources as lightweight models so you can 
 - `vaidcord.bot.Bot`: high-level orchestration facade (`start`, `stop`, `send_message`, application helpers).
 - `vaidcord.gateway_runtime.GatewayRuntime`: gateway session lifecycle, identify flow, heartbeat, and dispatch loop.
 - `vaidcord.api_client.APIClient`: REST layer used by `Bot`, backed by `HTTPClient`.
+- `APIClient` now also exposes convenience methods (`get/post/patch/put/delete`, `send_message`, `fetch_*`) for easier extension in app-level tooling.
 - `vaidcord.dispatcher.Dispatcher`: router/FSM lifecycle and startup modes, typed against a narrow bot protocol instead of a concrete `Bot`.
 
 ## Models

--- a/vaidcord-py/docs/APPLICATION_API.md
+++ b/vaidcord-py/docs/APPLICATION_API.md
@@ -2,6 +2,13 @@
 
 VaidCord exposes Discord application resources as lightweight models so you can work with structured data instead of raw payload dictionaries.
 
+## Layer map (after modular refactor)
+
+- `vaidcord.bot.Bot`: high-level orchestration facade (`start`, `stop`, `send_message`, application helpers).
+- `vaidcord.gateway_runtime.GatewayRuntime`: gateway session lifecycle, identify flow, heartbeat, and dispatch loop.
+- `vaidcord.api_client.APIClient`: REST layer used by `Bot`, backed by `HTTPClient`.
+- `vaidcord.dispatcher.Dispatcher`: router/FSM lifecycle and startup modes, typed against a narrow bot protocol instead of a concrete `Bot`.
+
 ## Models
 
 - `Application` represents the current Discord application or bot app record.

--- a/vaidcord-py/src/vaidcord/api_client.py
+++ b/vaidcord-py/src/vaidcord/api_client.py
@@ -6,13 +6,49 @@ from vaidcord.http import HTTPClient, HTTPConfig
 
 
 class APIClient:
-    """Discord REST API client facade built on top of HTTPClient."""
+    """Discord REST API facade with endpoint helpers on top of HTTPClient."""
 
     def __init__(self, token: str, *, base_url: str = "https://discord.com/api", api_version: str = "10") -> None:
         self._http = HTTPClient(HTTPConfig(token=token, base_url=base_url, api_version=api_version))
 
+    def _normalize_endpoint(self, endpoint: str) -> str:
+        if not endpoint.startswith("/"):
+            return f"/{endpoint}"
+        return endpoint
+
     async def request(self, method: str, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        endpoint = self._normalize_endpoint(endpoint)
         return await self._http.request(method, endpoint, **kwargs)
+
+    async def get(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        return await self.request("GET", endpoint, **kwargs)
+
+    async def post(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        return await self.request("POST", endpoint, **kwargs)
+
+    async def patch(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        return await self.request("PATCH", endpoint, **kwargs)
+
+    async def put(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        return await self.request("PUT", endpoint, **kwargs)
+
+    async def delete(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        return await self.request("DELETE", endpoint, **kwargs)
+
+    async def send_message(self, channel_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self.post(f"/channels/{channel_id}/messages", json=payload)
+
+    async def trigger_typing(self, channel_id: int) -> dict[str, Any]:
+        return await self.post(f"/channels/{channel_id}/typing")
+
+    async def fetch_channel(self, channel_id: int) -> dict[str, Any]:
+        return await self.get(f"/channels/{channel_id}")
+
+    async def fetch_guild(self, guild_id: int) -> dict[str, Any]:
+        return await self.get(f"/guilds/{guild_id}")
+
+    async def fetch_user(self, user_id: int) -> dict[str, Any]:
+        return await self.get(f"/users/{user_id}")
 
     async def close(self) -> None:
         await self._http.close()

--- a/vaidcord-py/src/vaidcord/api_client.py
+++ b/vaidcord-py/src/vaidcord/api_client.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any
+
+from vaidcord.http import HTTPClient, HTTPConfig
+
+
+class APIClient:
+    """Discord REST API client facade built on top of HTTPClient."""
+
+    def __init__(self, token: str, *, base_url: str = "https://discord.com/api", api_version: str = "10") -> None:
+        self._http = HTTPClient(HTTPConfig(token=token, base_url=base_url, api_version=api_version))
+
+    async def request(self, method: str, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._http.request(method, endpoint, **kwargs)
+
+    async def close(self) -> None:
+        await self._http.close()

--- a/vaidcord-py/src/vaidcord/bot.py
+++ b/vaidcord-py/src/vaidcord/bot.py
@@ -170,8 +170,7 @@ class Bot(Router):
     @property
     def latency(self) -> float:
         """Get the WebSocket latency in seconds."""
-        # Will be implemented with heartbeat ack tracking
-        return 0.0
+        return self.runtime.latency
 
     async def _create_session(self) -> aiohttp.ClientSession:
         """Create an aiohttp session for API requests."""
@@ -459,11 +458,7 @@ class Bot(Router):
                 "send_message requires at least one of content/embeds/components/"
                 "sticker_ids/message_reference"
             )
-        return await self.request(
-            "POST",
-            f"/channels/{channel_id}/messages",
-            json=payload,
-        )
+        return await self.api_client.send_message(channel_id, payload)
 
     async def reply(
         self,
@@ -532,7 +527,7 @@ class Bot(Router):
 
     async def trigger_typing(self, channel_id: int) -> None:
         """Trigger a typing indicator in a channel."""
-        await self.request("POST", f"/channels/{channel_id}/typing")
+        await self.api_client.trigger_typing(channel_id)
 
     async def delete_webhook(self, *, drop_pending_updates: bool = False) -> dict[str, Any]:
         """Compatibility helper for aiogram-like startup flows."""
@@ -576,21 +571,21 @@ class Bot(Router):
 
     async def fetch_channel(self, channel_id: int) -> Channel:
         """Fetch and parse a channel from the API."""
-        data = await self.request("GET", f"/channels/{channel_id}")
+        data = await self.api_client.fetch_channel(channel_id)
         channel = self._parse_channel(data)
         self._channels[channel.id] = channel
         return channel
 
     async def fetch_guild(self, guild_id: int) -> Guild:
         """Fetch and parse a guild from the API."""
-        data = await self.request("GET", f"/guilds/{guild_id}")
+        data = await self.api_client.fetch_guild(guild_id)
         guild = self._parse_guild(data)
         self._guilds[guild.id] = guild
         return guild
 
     async def fetch_user(self, user_id: int) -> User:
         """Fetch and parse a user from the API."""
-        data = await self.request("GET", f"/users/{user_id}")
+        data = await self.api_client.fetch_user(user_id)
         user = self._parse_user(data)
         self._users[user.id] = user
         return user

--- a/vaidcord-py/src/vaidcord/bot.py
+++ b/vaidcord-py/src/vaidcord/bot.py
@@ -8,7 +8,6 @@ for creating Discord bots with VaidCord.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from dataclasses import dataclass
 from enum import Enum, IntFlag
@@ -17,6 +16,8 @@ from typing import Any
 import aiohttp
 
 from vaidcord.application import Application, ApplicationRoleConnectionMetadata
+from vaidcord.api_client import APIClient
+from vaidcord.gateway_runtime import GatewayRuntime
 from vaidcord.router import Router
 from vaidcord.types import (
     Channel,
@@ -126,13 +127,16 @@ class Bot(Router):
 
         self.config = config
         self._session: aiohttp.ClientSession | None = None
-        self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._running = False
         self._sequence: int | None = None
         self._session_id: str | None = None
-        self._heartbeat_interval: float | None = None
-        self._heartbeat_task: asyncio.Task | None = None
         self._state = BotState.IDLE
+        self.api_client = APIClient(
+            token=self.config.token,
+            base_url=self.config.base_url,
+            api_version=self.config.api_version,
+        )
+        self.runtime = GatewayRuntime(self)
 
         # Cache for guilds, users, channels
         self._guilds: dict[int, Guild] = {}
@@ -188,88 +192,21 @@ class Bot(Router):
         endpoint: str,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """
-        Make an API request to Discord.
+        """Make an API request to Discord."""
+        return await self.api_client.request(method, endpoint, **kwargs)
 
-        Args:
-            method: HTTP method (GET, POST, PUT, DELETE, etc.)
-            endpoint: API endpoint (e.g., "/channels/123/messages")
-            **kwargs: Additional arguments for the request
-
-        Returns:
-            JSON response from the API
-        """
-        session = await self._create_session()
-        url = f"{self.config.base_url}/v{self.config.api_version}{endpoint}"
-
-        async with session.request(method, url, **kwargs) as response:
-            if response.status >= 400:
-                error_text = await response.text()
-                raise RuntimeError(f"API error {response.status}: {error_text}")
-            return await response.json()
 
     async def _connect_gateway(self) -> None:
-        """Connect to the Discord gateway."""
-        self._state = BotState.CONNECTING
-        if self._session is None:
-            await self._create_session()
-
-        # Use authenticated endpoint so we can track shard recommendations.
-        gateway_info = await self.request("GET", "/gateway/bot")
-        ws_url = gateway_info.get("url", self.config.gateway_url)
-        recommended_shards = gateway_info.get("shards")
-        if isinstance(recommended_shards, int) and recommended_shards > 0:
-            if self.config.shard_count < recommended_shards:
-                logger.info(
-                    "Gateway recommends %s shard(s); current config uses %s",
-                    recommended_shards,
-                    self.config.shard_count,
-                )
-
-        # Connect to WebSocket
-        self._ws = await self._session.ws_connect(
-            f"{ws_url}?v={self.config.api_version}&encoding=json"
-        )
-        logger.info("Connected to Discord gateway")
+        await self.runtime.connect()
 
     async def _send_payload(self, payload: dict[str, Any]) -> None:
-        """Send a payload to the gateway."""
-        if self._ws and not self._ws.closed:
-            await self._ws.send_json(payload)
+        await self.runtime.send_payload(payload)
 
     async def _identify(self) -> None:
-        """Send the identify payload to authenticate."""
-        self._state = BotState.IDENTIFYING
-        payload = {
-            "op": 2,  # Identify
-            "d": {
-                "token": self.config.token,
-                "intents": int(self.config.intents),
-                "properties": {
-                    "os": "linux",
-                    "browser": "VaidCord",
-                    "device": "VaidCord",
-                },
-                "compress": False,
-                "large_threshold": 250,
-            },
-        }
-
-        if self.config.shard_count > 1:
-            payload["d"]["shard"] = [self.config.shard_id, self.config.shard_count]
-
-        if self.config.presence:
-            payload["d"]["presence"] = self.config.presence
-
-        await self._send_payload(payload)
-        logger.info("Sent identify payload")
+        await self.runtime.identify()
 
     async def _heartbeat(self) -> None:
-        """Send heartbeats to keep the connection alive."""
-        while self._running and self._heartbeat_interval is not None:
-            await asyncio.sleep(self._heartbeat_interval / 1000)
-            await self._send_payload({"op": 1, "d": self._sequence})
-            logger.debug("Sent heartbeat")
+        return None
 
     async def _handle_dispatch(self, data: dict[str, Any]) -> None:
         """Handle a dispatch event from the gateway."""
@@ -433,35 +370,7 @@ class Bot(Router):
         )
 
     async def _receive_messages(self) -> None:
-        """Receive and process messages from the gateway."""
-        if not self._ws:
-            return
-
-        async for msg in self._ws:
-            if msg.type == aiohttp.WSMsgType.TEXT:
-                data = json.loads(msg.data)
-                op = data.get("op")
-
-                if op == 0:  # Dispatch
-                    await self._handle_dispatch(data)
-                elif op == 9:  # Invalid Session
-                    logger.warning("Invalid session, reidentifying...")
-                    self._state = BotState.RECONNECTING
-                    await asyncio.sleep(5)
-                    await self._identify()
-                elif op == 10:  # Hello
-                    self._heartbeat_interval = data["d"]["heartbeat_interval"]
-                    logger.info(f"Heartbeat interval: {self._heartbeat_interval}ms")
-                    await self._identify()
-                    if self._heartbeat_task:
-                        self._heartbeat_task.cancel()
-                    self._heartbeat_task = asyncio.create_task(self._heartbeat())
-                elif op == 11:  # Heartbeat ACK
-                    logger.debug("Received heartbeat ACK")
-
-            elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
-                logger.warning(f"WebSocket closed/error: {msg.type}")
-                break
+        await self.runtime.run()
 
     async def start(self) -> None:
         """Start the bot client."""
@@ -499,14 +408,8 @@ class Bot(Router):
         self._state = BotState.STOPPING
         self._ready_event.clear()
 
-        if self._heartbeat_task:
-            self._heartbeat_task.cancel()
-            self._heartbeat_task = None
-
-        if self._ws and not self._ws.closed:
-            await self._ws.close()
-            self._ws = None
-
+        await self.runtime.stop()
+        await self.api_client.close()
         await self._close_session()
         self._state = BotState.STOPPED
         logger.info("Bot stopped")

--- a/vaidcord-py/src/vaidcord/dispatcher.py
+++ b/vaidcord-py/src/vaidcord/dispatcher.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Protocol
 
-from vaidcord.bot import Bot
 from vaidcord.fsm import FSMMiddleware, MemoryFSMStorage
 from vaidcord.router import Router
+
+
+class DispatcherBotProtocol(Protocol):
+    def include_router(self, router: Router) -> None: ...
+
+    async def start(self) -> None: ...
+
+    async def delete_webhook(self, *, drop_pending_updates: bool = False) -> dict[str, Any]: ...
 
 
 class Dispatcher(Router):
@@ -12,7 +19,7 @@ class Dispatcher(Router):
 
     def __init__(
         self,
-        bot: Bot | None = None,
+        bot: DispatcherBotProtocol | None = None,
         *,
         fsm: FSMMiddleware | None = None,
         storage: Any | None = None,
@@ -47,7 +54,7 @@ class Dispatcher(Router):
             raise ValueError("Dispatcher cannot include another Dispatcher")
         super().include_router(router)
 
-    async def start_polling(self, bot: Bot) -> None:
+    async def start_polling(self, bot: DispatcherBotProtocol) -> None:
         """
         Start bot and route events through dispatcher routers.
         """
@@ -60,11 +67,11 @@ class Dispatcher(Router):
         finally:
             await self.shutdown()
 
-    async def start_websocket(self, bot: Bot) -> None:
+    async def start_websocket(self, bot: DispatcherBotProtocol) -> None:
         """Alias for explicit websocket startup."""
         await self.start_polling(bot)
 
-    async def start_webhook(self, bot: Bot, *, drop_pending_updates: bool = False) -> None:
+    async def start_webhook(self, bot: DispatcherBotProtocol, *, drop_pending_updates: bool = False) -> None:
         """Webhook-style startup helper (webhook server integration is app-defined)."""
         await bot.delete_webhook(drop_pending_updates=drop_pending_updates)
         await self.start_polling(bot)

--- a/vaidcord-py/src/vaidcord/dispatcher.py
+++ b/vaidcord-py/src/vaidcord/dispatcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Protocol
 
 from vaidcord.fsm import FSMMiddleware, MemoryFSMStorage
@@ -30,6 +31,8 @@ class Dispatcher(Router):
         resolved_storage = storage or MemoryFSMStorage()
         self.fsm = fsm or FSMMiddleware(storage=resolved_storage)
         self.add_middleware(self.fsm)
+        self._active_bots: set[DispatcherBotProtocol] = set()
+        self._started = False
         if bot is not None:
             self.provide("bot", bot)
 
@@ -61,17 +64,42 @@ class Dispatcher(Router):
         self.bot = bot
         self.provide("bot", bot)
         bot.include_router(self)
-        await self.startup()
+        self._active_bots.add(bot)
+        if not self._started:
+            await self.startup()
+            self._started = True
         try:
             await bot.start()
         finally:
-            await self.shutdown()
+            self._active_bots.discard(bot)
+            if not self._active_bots and self._started:
+                await self.shutdown()
+                self._started = False
 
     async def start_websocket(self, bot: DispatcherBotProtocol) -> None:
         """Alias for explicit websocket startup."""
         await self.start_polling(bot)
 
+    async def start_polling_many(self, bots: list[DispatcherBotProtocol]) -> None:
+        """Start multiple bots concurrently with shared dispatcher wiring."""
+        if not bots:
+            raise ValueError("start_polling_many requires at least one bot")
+        await asyncio.gather(*(self.start_polling(bot) for bot in bots))
+
     async def start_webhook(self, bot: DispatcherBotProtocol, *, drop_pending_updates: bool = False) -> None:
         """Webhook-style startup helper (webhook server integration is app-defined)."""
         await bot.delete_webhook(drop_pending_updates=drop_pending_updates)
         await self.start_polling(bot)
+
+    async def start_webhook_many(
+        self,
+        bots: list[DispatcherBotProtocol],
+        *,
+        drop_pending_updates: bool = False,
+    ) -> None:
+        """Webhook-style startup for multiple bots concurrently."""
+        if not bots:
+            raise ValueError("start_webhook_many requires at least one bot")
+        await asyncio.gather(
+            *(self.start_webhook(bot, drop_pending_updates=drop_pending_updates) for bot in bots)
+        )

--- a/vaidcord-py/src/vaidcord/gateway_runtime.py
+++ b/vaidcord-py/src/vaidcord/gateway_runtime.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+if TYPE_CHECKING:
+    from vaidcord.bot import Bot
+
+logger = logging.getLogger(__name__)
+
+
+class GatewayRuntime:
+    """Owns gateway lifecycle and websocket state machine for Bot."""
+
+    def __init__(self, bot: Bot) -> None:
+        self._bot = bot
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._heartbeat_interval: float | None = None
+        self._heartbeat_task: asyncio.Task | None = None
+
+    @property
+    def ws(self) -> aiohttp.ClientWebSocketResponse | None:
+        return self._ws
+
+    async def connect(self) -> None:
+        from vaidcord.bot import BotState
+
+        self._bot._state = BotState.CONNECTING
+        gateway_info = await self._bot.api_client.request("GET", "/gateway/bot")
+        ws_url = gateway_info.get("url", self._bot.config.gateway_url)
+        self._ws = await self._bot._create_session().ws_connect(
+            f"{ws_url}?v={self._bot.config.api_version}&encoding=json"
+        )
+
+    async def send_payload(self, payload: dict[str, Any]) -> None:
+        if self._ws and not self._ws.closed:
+            await self._ws.send_json(payload)
+
+    async def identify(self) -> None:
+        from vaidcord.bot import BotState
+
+        self._bot._state = BotState.IDENTIFYING
+        payload: dict[str, Any] = {
+            "op": 2,
+            "d": {
+                "token": self._bot.config.token,
+                "intents": int(self._bot.config.intents),
+                "properties": {"os": "linux", "browser": "VaidCord", "device": "VaidCord"},
+                "compress": False,
+                "large_threshold": 250,
+            },
+        }
+        if self._bot.config.shard_count > 1:
+            payload["d"]["shard"] = [self._bot.config.shard_id, self._bot.config.shard_count]
+        if self._bot.config.presence:
+            payload["d"]["presence"] = self._bot.config.presence
+        await self.send_payload(payload)
+
+    async def _heartbeat(self) -> None:
+        while self._bot._running and self._heartbeat_interval is not None:
+            await asyncio.sleep(self._heartbeat_interval / 1000)
+            await self.send_payload({"op": 1, "d": self._bot._sequence})
+
+    async def run(self) -> None:
+        if not self._ws:
+            return
+        async for msg in self._ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                data = json.loads(msg.data)
+                op = data.get("op")
+                if op == 0:
+                    await self._bot._handle_dispatch(data)
+                elif op == 9:
+                    from vaidcord.bot import BotState
+
+                    self._bot._state = BotState.RECONNECTING
+                    await asyncio.sleep(5)
+                    await self.identify()
+                elif op == 10:
+                    self._heartbeat_interval = data["d"]["heartbeat_interval"]
+                    await self.identify()
+                    if self._heartbeat_task:
+                        self._heartbeat_task.cancel()
+                    self._heartbeat_task = asyncio.create_task(self._heartbeat())
+                elif op == 11:
+                    logger.debug("Received heartbeat ACK")
+            elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                break
+
+    async def stop(self) -> None:
+        if self._heartbeat_task:
+            self._heartbeat_task.cancel()
+            self._heartbeat_task = None
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None

--- a/vaidcord-py/src/vaidcord/gateway_runtime.py
+++ b/vaidcord-py/src/vaidcord/gateway_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
@@ -21,10 +22,16 @@ class GatewayRuntime:
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._heartbeat_interval: float | None = None
         self._heartbeat_task: asyncio.Task | None = None
+        self._last_heartbeat_sent_at: float | None = None
+        self._latency: float = 0.0
 
     @property
     def ws(self) -> aiohttp.ClientWebSocketResponse | None:
         return self._ws
+
+    @property
+    def latency(self) -> float:
+        return self._latency
 
     async def connect(self) -> None:
         from vaidcord.bot import BotState
@@ -63,6 +70,7 @@ class GatewayRuntime:
     async def _heartbeat(self) -> None:
         while self._bot._running and self._heartbeat_interval is not None:
             await asyncio.sleep(self._heartbeat_interval / 1000)
+            self._last_heartbeat_sent_at = time.monotonic()
             await self.send_payload({"op": 1, "d": self._bot._sequence})
 
     async def run(self) -> None:
@@ -87,6 +95,8 @@ class GatewayRuntime:
                         self._heartbeat_task.cancel()
                     self._heartbeat_task = asyncio.create_task(self._heartbeat())
                 elif op == 11:
+                    if self._last_heartbeat_sent_at is not None:
+                        self._latency = time.monotonic() - self._last_heartbeat_sent_at
                     logger.debug("Received heartbeat ACK")
             elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
                 break


### PR DESCRIPTION
### Motivation

- Уменьшить связанность и разделить ответственность между REST-слоем, gateway state-machine и фасадным ботом. 
- Вынести HTTP-логику из `Bot.request` в отдельный клиент, чтобы переиспользовать `HTTPClient` и упростить тестирование/расширение. 
- Выделить lifecycle WebSocket/heartbeat/identify в отдельный runtime-класс для чистого orchestration-слоя в `Bot`.

### Description

- Добавлен `vaidcord.api_client.APIClient` — тонкий фасад над `HTTPClient` (`HTTPConfig`) с методами `request` и `close` (`src/vaidcord/api_client.py`).
- Добавлен `vaidcord.gateway_runtime.GatewayRuntime`, который управляет подключением к gateway, `identify`, heartbeat и циклом обработки сообщений (`src/vaidcord/gateway_runtime.py`).
- `Bot` оставлен как фасад/orchestrator: теперь держит `api_client` и `runtime`, и прежние методы `request`, `_connect_gateway`, `_identify`, `_receive_messages` являются делегирующими shim’ами, при этом публичный high-level API (`start`, `stop`, `send_message`, application helpers) сохранён (`src/vaidcord/bot.py`).
- Ослаблена связность `Dispatcher` к конкретной реализации `Bot` введением узкого `DispatcherBotProtocol` и изменением сигнатур startup/ webhook методов на протокол-тип (`src/vaidcord/dispatcher.py`).
- Обновлены документы с картой слоёв и краткой ответственностью: `README.md` и `docs/APPLICATION_API.md`.

### Testing

- Выполнена статическая проверка синтаксиса через `python -m py_compile` для `src/vaidcord/bot.py`, `src/vaidcord/gateway_runtime.py`, `src/vaidcord/api_client.py` и `src/vaidcord/dispatcher.py`, которая прошла успешно. 
- Попытка запустить модульные тесты `PYTHONPATH=src pytest -q tests/test_bot.py` завершилась ошибкой на этапе импорта из-за отсутствующей системной зависимости `aiohttp` в текущем окружении, поэтому тесты не были выполнены. 
- Предыдущая попытка запуска `pytest` без `PYTHONPATH` также завершилась на этапе коллекции из-за окружения; код компилируется, но интеграционные/рантайм-тесты требуют установки зависимостей.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a8749354832a909c921caa4a3137)