### PR TITLE
Tighten dispatcher and FSM typing contracts

### DIFF
--- a/vaidcord-py/src/vaidcord/__init__.py
+++ b/vaidcord-py/src/vaidcord/__init__.py
@@ -30,6 +30,10 @@ __lazy_imports__ = {
     "ApplicationRoleConnectionMetadata": ".application",
     "ApplicationRoleConnectionMetadataType": ".application",
     "Middleware": ".router",
+    "NextHandler": ".router",
+    "Handler": ".router",
+    "EventHandlerResult": ".router",
+    "LifecycleHandler": ".router",
     "RouterFilterConfig": ".router",
     # Filters
     "F": ".filters",
@@ -104,6 +108,7 @@ __lazy_imports__ = {
     "PostgresFSMStorage": ".fsm",
     "StateValue": ".fsm",
     "StorageKey": ".fsm",
+    "BaseFSMStorage": ".fsm",
 }
 
 
@@ -128,6 +133,10 @@ __all__ = [
     "ApplicationRoleConnectionMetadata",
     "ApplicationRoleConnectionMetadataType",
     "Middleware",
+    "NextHandler",
+    "Handler",
+    "EventHandlerResult",
+    "LifecycleHandler",
     "RouterFilterConfig",
     "F",
     "FilterExpr",
@@ -207,6 +216,7 @@ __all__ = [
     "PostgresFSMStorage",
     "StateValue",
     "StorageKey",
+    "BaseFSMStorage",
     # Version
     "__version__",
 ]

--- a/vaidcord-py/src/vaidcord/dispatcher.py
+++ b/vaidcord-py/src/vaidcord/dispatcher.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Protocol
 
-from vaidcord.fsm import FSMMiddleware, MemoryFSMStorage
-from vaidcord.router import Router
+from vaidcord.fsm import BaseFSMStorage, FSMMiddleware, MemoryFSMStorage
+from vaidcord.router import EventHandlerResult, Router
+from vaidcord.types import Event
 
 
 class DispatcherBotProtocol(Protocol):
@@ -23,7 +24,7 @@ class Dispatcher(Router):
         bot: DispatcherBotProtocol | None = None,
         *,
         fsm: FSMMiddleware | None = None,
-        storage: Any | None = None,
+        storage: BaseFSMStorage | None = None,
         name: str = "dispatcher",
     ) -> None:
         super().__init__(name=name)
@@ -49,7 +50,7 @@ class Dispatcher(Router):
     async def reconnect(self) -> None:
         await self.emit_reconnect()
 
-    async def feed_event(self, event: Any) -> Any:
+    async def feed_event(self, event: Event) -> EventHandlerResult:
         return await self.propagate_event(event)
 
     def include_router(self, router: Router) -> None:

--- a/vaidcord-py/src/vaidcord/fsm/__init__.py
+++ b/vaidcord-py/src/vaidcord/fsm/__init__.py
@@ -1,4 +1,4 @@
-from .context import FSMContext, FSMManager, FSMMiddleware
+from .context import FSMContext, FSMManager, FSMMiddleware, FSMNextHandler
 from .storage import (
     BaseFSMStorage,
     FSMScope,
@@ -24,4 +24,5 @@ __all__ = [
     "FSMContext",
     "FSMManager",
     "FSMMiddleware",
+    "FSMNextHandler",
 ]

--- a/vaidcord-py/src/vaidcord/fsm/context.py
+++ b/vaidcord-py/src/vaidcord/fsm/context.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeAlias
 
 from vaidcord.types import Event
 
@@ -56,6 +57,9 @@ class FSMManager:
         return FSMContext(self.storage, StorageKey.custom(custom_id))
 
 
+FSMNextHandler: TypeAlias = Callable[[Event], Awaitable[object | None]]
+
+
 @dataclass
 class FSMMiddleware:
     storage: BaseFSMStorage = field(default_factory=MemoryFSMStorage)
@@ -68,7 +72,7 @@ class FSMMiddleware:
         FSMScope.GUILD,
     )
 
-    async def __call__(self, event: Event, handler: Any) -> Any:
+    async def __call__(self, event: Event, handler: FSMNextHandler) -> object | None:
         manager = FSMManager(self.storage)
         event.context["fsm_manager"] = manager
 

--- a/vaidcord-py/src/vaidcord/router.py
+++ b/vaidcord-py/src/vaidcord/router.py
@@ -25,9 +25,12 @@ from vaidcord.filters import (
 from vaidcord.types import ChannelType, Event, EventType
 
 T = TypeVar("T")
-Handler = Callable[[Event], Awaitable[Any]]
-NextHandler = Callable[[Event], Awaitable[Any]]
-Middleware = Callable[[Event, NextHandler], Awaitable[Any]]
+
+EventHandlerResult = object | None
+Handler = Callable[[Event], Awaitable[EventHandlerResult]]
+NextHandler = Callable[[Event], Awaitable[EventHandlerResult]]
+Middleware = Callable[[Event, NextHandler], Awaitable[EventHandlerResult]]
+LifecycleHandler = Callable[[], Awaitable[None]]
 Filter = FilterLike
 
 
@@ -82,9 +85,9 @@ class Router:
         self._middlewares: list[MiddlewareConfig] = []
         self._router_filters: list[RouterFilterConfig] = []
         self._dependencies: dict[str, Any] = {}
-        self._startup_handlers: list[Callable[[], Awaitable[Any]]] = []
-        self._shutdown_handlers: list[Callable[[], Awaitable[Any]]] = []
-        self._reconnect_handlers: list[Callable[[], Awaitable[Any]]] = []
+        self._startup_handlers: list[LifecycleHandler] = []
+        self._shutdown_handlers: list[LifecycleHandler] = []
+        self._reconnect_handlers: list[LifecycleHandler] = []
 
     def _resolve_event_types(self, *event_types: EventType | str) -> list[EventType]:
         """Resolve event types from arguments."""
@@ -336,20 +339,20 @@ class Router:
         deps.update(self._dependencies)
         return deps
 
-    def on_startup(self) -> Callable[[Callable[[], Awaitable[Any]]], Callable[[], Awaitable[Any]]]:
-        def decorator(handler: Callable[[], Awaitable[Any]]) -> Callable[[], Awaitable[Any]]:
+    def on_startup(self) -> Callable[[LifecycleHandler], LifecycleHandler]:
+        def decorator(handler: LifecycleHandler) -> LifecycleHandler:
             self._startup_handlers.append(handler)
             return handler
         return decorator
 
-    def on_shutdown(self) -> Callable[[Callable[[], Awaitable[Any]]], Callable[[], Awaitable[Any]]]:
-        def decorator(handler: Callable[[], Awaitable[Any]]) -> Callable[[], Awaitable[Any]]:
+    def on_shutdown(self) -> Callable[[LifecycleHandler], LifecycleHandler]:
+        def decorator(handler: LifecycleHandler) -> LifecycleHandler:
             self._shutdown_handlers.append(handler)
             return handler
         return decorator
 
-    def on_reconnect(self) -> Callable[[Callable[[], Awaitable[Any]]], Callable[[], Awaitable[Any]]]:
-        def decorator(handler: Callable[[], Awaitable[Any]]) -> Callable[[], Awaitable[Any]]:
+    def on_reconnect(self) -> Callable[[LifecycleHandler], LifecycleHandler]:
+        def decorator(handler: LifecycleHandler) -> LifecycleHandler:
             self._reconnect_handlers.append(handler)
             return handler
         return decorator
@@ -474,8 +477,8 @@ class Router:
         self,
         event: Event,
         handler: Handler,
-    ) -> Any:
-        async def call(index: int, current_event: Event) -> Any:
+    ) -> EventHandlerResult:
+        async def call(index: int, current_event: Event) -> EventHandlerResult:
             if index >= len(chain):
                 return await handler(current_event)
             middleware = chain[index]
@@ -484,7 +487,7 @@ class Router:
         chain = self._resolve_middleware_chain(event.type)
         return await call(0, event)
 
-    async def propagate_event(self, event: Event) -> Any:
+    async def propagate_event(self, event: Event) -> EventHandlerResult:
         """
         Propagate an event through all registered handlers.
 
@@ -511,7 +514,7 @@ class Router:
             item.filter_obj for item in self._resolve_router_filter_configs(event.type)
         ]
         for config in handlers:
-            async def guarded_handler(current_event: Event) -> Any:
+            async def guarded_handler(current_event: Event) -> EventHandlerResult:
                 filter_data: dict[str, Any] = {}
                 for filter_func in [*router_filters, *config.filters]:
                     try:


### PR DESCRIPTION
### Motivation
- Remove unsafe `Any` annotations and provide clear, importable type contracts for dispatcher/FSM middleware to improve IDE support and public API clarity.
- Align `Dispatcher.feed_event` and middleware/lifecycle signatures with `Router.propagate_event` to make propagation result types explicit and consistent.
- Export reusable type aliases for external users so third-party code can reference the same callable contracts.

### Description
- Replaced the `Dispatcher` storage parameter type from `Any | None` to `BaseFSMStorage | None` and adjusted imports in `vaidcord/dispatcher.py`, and typed `feed_event` as `async def feed_event(self, event: Event) -> EventHandlerResult`.
- Introduced public router type aliases in `vaidcord/router.py`: `EventHandlerResult`, `Handler`, `NextHandler`, `Middleware`, and `LifecycleHandler`, and updated lifecycle handler lists and decorators to use `LifecycleHandler` as well as tightened return types for `_execute_with_middlewares`, `propagate_event`, and internal `guarded_handler`.
- Added `FSMNextHandler` alias and replaced `Any` in the `FSMMiddleware.__call__` handler signature with `FSMNextHandler` in `vaidcord/fsm/context.py`, and exported `FSMNextHandler` from `vaidcord/fsm/__init__.py`.
- Exposed new public typing aliases (`Handler`, `NextHandler`, `EventHandlerResult`, `LifecycleHandler`, and `BaseFSMStorage`) via lazy imports and `__all__` in the package root `vaidcord/__init__.py`.

### Testing
- Ran `cd vaidcord-py && pytest -q` which failed during collection with `ModuleNotFoundError: No module named 'vaidcord'` when the package was not importable in the test runner environment.
- Ran `cd vaidcord-py && PYTHONPATH=src pytest -q tests/test_router_fsm.py tests/test_fsm_storage.py` which executed tests but many async tests failed because the environment lacks an async pytest plugin (e.g. `pytest-asyncio`); one run reported `16 failed, 2 passed` due to the missing plugin.
- The changes are types-only at runtime and do not alter behavioral logic, and the failures are due to test environment configuration rather than the typing adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ab889864832abbf28929f18e4b1d)