### PR TITLE
Preserve and merge dict payloads in filter composition

### DIFF
--- a/vaidcord-py/README.md
+++ b/vaidcord-py/README.md
@@ -46,6 +46,19 @@ uv add "vaidcord[postgres]"
 - Use `@router.on_message_state(...)` when a flow depends on FSM state.
 - Use `MockBot` or `MockDiscordServer` for deterministic tests.
 
+## Filter composition semantics
+
+- Filter may return `bool` or `dict`.
+- `dict` means: filter passed and payload is injected into `event.context["filter_data"]` and handler kwargs (by parameter name).
+- `A & B`: both filters must pass; dict payloads from both sides are merged left-to-right.
+- `A | B`: first passing filter wins; payload from that branch is used.
+
+```python
+@router.on_message((F.message.content.startswith("!admin")) & my_role_filter)
+async def admin_handler(event: Event, role: str | None = None):
+    ...
+```
+
 ## Runtime modes
 
 ```python

--- a/vaidcord-py/src/vaidcord/filters.py
+++ b/vaidcord-py/src/vaidcord/filters.py
@@ -61,9 +61,25 @@ async def run_filter_with_data(
     return bool(result), {}
 
 
+def _to_pass_and_data(result: bool | dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    if isinstance(result, dict):
+        return True, result
+    return bool(result), {}
+
+
 @dataclass(frozen=True)
 class FilterExpr:
-    """Composable filter expression (`&`, `|`, `~`)."""
+    """Composable filter expression (`&`, `|`, `~`).
+
+    Result semantics:
+    - `bool`: pass/fail only.
+    - `dict`: pass + data payload for handler kwargs/context injection.
+
+    Composition rules:
+    - `A & B`: both must pass; dict payloads are merged from left to right.
+    - `A | B`: first passing branch wins; returns dict payload from that branch if present.
+    - `~A`: boolean negation (payloads are not propagated).
+    """
 
     callback: FilterCallable
 
@@ -76,16 +92,36 @@ class FilterExpr:
     def __and__(self, other: FilterLike) -> FilterExpr:
         other_expr = as_filter(other)
 
-        async def _and(event: Event) -> bool:
-            return await self(event) and await other_expr(event)
+        async def _and(event: Event) -> bool | dict[str, Any]:
+            left_result = await self(event)
+            left_passed, left_data = _to_pass_and_data(left_result)
+            if not left_passed:
+                return False
+
+            right_result = await other_expr(event)
+            right_passed, right_data = _to_pass_and_data(right_result)
+            if not right_passed:
+                return False
+
+            merged = {**left_data, **right_data}
+            return merged or True
 
         return FilterExpr(_and)
 
     def __or__(self, other: FilterLike) -> FilterExpr:
         other_expr = as_filter(other)
 
-        async def _or(event: Event) -> bool:
-            return await self(event) or await other_expr(event)
+        async def _or(event: Event) -> bool | dict[str, Any]:
+            left_result = await self(event)
+            left_passed, left_data = _to_pass_and_data(left_result)
+            if left_passed:
+                return left_data or True
+
+            right_result = await other_expr(event)
+            right_passed, right_data = _to_pass_and_data(right_result)
+            if right_passed:
+                return right_data or True
+            return False
 
         return FilterExpr(_or)
 
@@ -104,8 +140,11 @@ def as_filter(filter_like: FilterLike) -> FilterExpr:
     if isinstance(filter_like, FilterExpr):
         return filter_like
 
-    async def _cb(event: Event) -> bool:
-        return await run_filter(filter_like, event)
+    async def _cb(event: Event) -> bool | dict[str, Any]:
+        result = filter_like(event)
+        if inspect.isawaitable(result):
+            result = await result
+        return result
 
     return FilterExpr(_cb)
 

--- a/vaidcord-py/tests/test_filters.py
+++ b/vaidcord-py/tests/test_filters.py
@@ -16,6 +16,7 @@ from vaidcord.filters import (
     RegexFilter,
     UserFilter,
     as_filter,
+    run_filter_with_data,
 )
 from vaidcord.router import Router
 from vaidcord.types import Channel, ChannelType, Event, EventType, Message, User
@@ -58,7 +59,7 @@ def _event_with_channel_type(text: str, channel_type: ChannelType, guild_id: str
 async def test_magic_filters_composition() -> None:
     event = _event_with_text("!admin ping")
     expr = F.message.content.startswith("!admin") & F.user.id.in_({10, 11})
-    assert await expr(event) is True
+    assert bool(await expr(event)) is True
 
     expr_not = ~F.message.content.contains("ban")
     assert await expr_not(event) is True
@@ -136,6 +137,50 @@ async def test_filter_dict_data_propagation_to_event_context() -> None:
 
     await router.propagate_event(_event_with_text("hello"))
     assert captured == {"role": "admin", "tenant": "main"}
+
+
+@pytest.mark.asyncio
+async def test_filter_expr_and_merges_dict_with_bool() -> None:
+    event = _event_with_text("hello")
+    left = as_filter(lambda _e: {"role": "admin"})
+    right = as_filter(lambda _e: True)
+
+    passed, data = await run_filter_with_data(left & right, event)
+    assert passed is True
+    assert data == {"role": "admin"}
+
+
+@pytest.mark.asyncio
+async def test_filter_expr_and_merges_dict_with_dict() -> None:
+    event = _event_with_text("hello")
+    left = as_filter(lambda _e: {"role": "admin"})
+    right = as_filter(lambda _e: {"tenant": "main"})
+
+    passed, data = await run_filter_with_data(left & right, event)
+    assert passed is True
+    assert data == {"role": "admin", "tenant": "main"}
+
+
+@pytest.mark.asyncio
+async def test_filter_expr_or_uses_first_successful_branch_data() -> None:
+    event = _event_with_text("hello")
+    first = as_filter(lambda _e: {"source": "first"})
+    second = as_filter(lambda _e: {"source": "second"})
+
+    passed, data = await run_filter_with_data(first | second, event)
+    assert passed is True
+    assert data == {"source": "first"}
+
+
+@pytest.mark.asyncio
+async def test_filter_expr_or_uses_second_branch_data_when_first_fails() -> None:
+    event = _event_with_text("hello")
+    first = as_filter(lambda _e: False)
+    second = as_filter(lambda _e: {"source": "second"})
+
+    passed, data = await run_filter_with_data(first | second, event)
+    assert passed is True
+    assert data == {"source": "second"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Filters can return either `bool` or `dict`, and dict results must be preserved and injected into handler kwargs/context during composition. 
- Current boolean-only composition caused `dict`-results to be lost when combining filters with `&`/`|`, preventing data propagation. 
- Composition semantics should follow Aiogram-like behavior where `dict` means pass + payload, with clear merge/selection rules. 

### Description
- Implemented merge-aware semantics for `FilterExpr` compositions by adding helper `_to_pass_and_data` and updating `__and__` to require both filters to pass and merge dict payloads left-to-right. 
- Updated `__or__` to return the first successful branch and its dict payload if present. 
- Changed `as_filter` to preserve original `bool | dict` return values (no longer collapsing to plain `bool`) so payloads flow through composed expressions. 
- Expanded `FilterExpr` docstring and updated `vaidcord-py/README.md` to document `bool`/`dict` semantics and composition rules. 
- Added tests in `vaidcord-py/tests/test_filters.py` covering `dict + bool` (AND), `dict + dict` (AND), `OR` with first/second successful branch data, and adjusted an existing assertion to account for dict-returning filters. 

### Testing
- Ran tests with virtual environment using `uv run pytest tests/test_filters.py -q` and all tests passed: `12 passed`. 
- An initial plain `pytest` run errored in the local environment due to import path setup (`ModuleNotFoundError`), but the package test run via `uv` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3acb08d50832a9cc06310d60085ea)