### PR TITLE
Add DM sending support, current-user REST endpoints, mock server DM handling, and tests

### DIFF
--- a/vaidcord-py/README.md
+++ b/vaidcord-py/README.md
@@ -46,6 +46,24 @@ uv add "vaidcord[postgres]"
 - Use `@router.on_message_state(...)` when a flow depends on FSM state.
 - Use `MockBot` or `MockDiscordServer` for deterministic tests.
 
+## Send DM to a user
+
+`Bot.send_dm(user_id, content, **kwargs)` opens or reuses the DM channel via
+`POST /users/@me/channels`, then sends the message with the same payload options
+as `send_message` (`embeds`, `components`, etc.).
+
+There is also an alias: `send_message_to_user(...)`.
+
+```python
+message = await bot.send_dm(
+    user_id=123456789012345678,
+    content="Hi from VaidCord!",
+    embeds=[{"title": "DM"}],
+)
+```
+
+See runnable example: [examples/send_dm_to_user.py](examples/send_dm_to_user.py).
+
 ## Filter composition semantics
 
 - Filter may return `bool` or `dict`.

--- a/vaidcord-py/examples/README.md
+++ b/vaidcord-py/examples/README.md
@@ -10,6 +10,7 @@ This directory collects small, focused examples instead of one large kitchen-sin
 - [mock_testing.py](mock_testing.py) - deterministic testing with the mock layer.
 - [oauth2_examples.py](oauth2_examples.py) - the minimal OAuth2 authorization URL helper.
 - [oauth2_workflow.py](oauth2_workflow.py) - a richer OAuth2 install and token helper example.
+- [send_dm_to_user.py](send_dm_to_user.py) - open a user DM channel and send a direct message by user ID.
 
 ## Run them
 
@@ -20,6 +21,7 @@ uv run python examples/fsm_conversation.py
 uv run python examples/mock_testing.py
 uv run python examples/oauth2_examples.py
 uv run python examples/oauth2_workflow.py
+uv run python examples/send_dm_to_user.py 123456789012345678 "Hello from VaidCord"
 ```
 
 The bot examples expect a `DISCORD_BOT_TOKEN` environment variable. The OAuth2 examples use placeholder values and are meant as templates.

--- a/vaidcord-py/examples/send_dm_to_user.py
+++ b/vaidcord-py/examples/send_dm_to_user.py
@@ -1,0 +1,34 @@
+"""Send a DM to a user by ID.
+
+Usage:
+  DISCORD_BOT_TOKEN=... uv run python examples/send_dm_to_user.py 123456789012345678 "Hello!"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from vaidcord.bot import Bot
+
+
+async def main() -> None:
+    if len(sys.argv) < 3:
+        print("Usage: python examples/send_dm_to_user.py <user_id> <message>")
+        raise SystemExit(1)
+
+    user_id = int(sys.argv[1])
+    content = sys.argv[2]
+
+    token = os.environ.get("DISCORD_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("Set DISCORD_BOT_TOKEN environment variable before running this example")
+
+    bot = Bot(token=token)
+    message = await bot.send_dm(user_id=user_id, content=content)
+    print(f"DM sent: message_id={message.id} channel_id={message.channel.id}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/vaidcord-py/src/vaidcord/api_client.py
+++ b/vaidcord-py/src/vaidcord/api_client.py
@@ -50,5 +50,23 @@ class APIClient:
     async def fetch_user(self, user_id: int) -> dict[str, Any]:
         return await self.get(f"/users/{user_id}")
 
+    async def get_current_user(self) -> dict[str, Any]:
+        return await self.get("/users/@me")
+
+    async def modify_current_user(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self.patch("/users/@me", json=payload)
+
+    async def get_current_user_guilds(self, **params: Any) -> list[dict[str, Any]]:
+        return await self.get("/users/@me/guilds", params=params)  # type: ignore[return-value]
+
+    async def get_current_user_guild_member(self, guild_id: int) -> dict[str, Any]:
+        return await self.get(f"/users/@me/guilds/{guild_id}/member")
+
+    async def leave_guild(self, guild_id: int) -> dict[str, Any]:
+        return await self.delete(f"/users/@me/guilds/{guild_id}")
+
+    async def create_dm(self, recipient_id: int) -> dict[str, Any]:
+        return await self.post("/users/@me/channels", json={"recipient_id": str(recipient_id)})
+
     async def close(self) -> None:
         await self._http.close()

--- a/vaidcord-py/src/vaidcord/bot.py
+++ b/vaidcord-py/src/vaidcord/bot.py
@@ -17,6 +17,7 @@ import aiohttp
 
 from vaidcord.application import Application, ApplicationRoleConnectionMetadata
 from vaidcord.api_client import APIClient
+from vaidcord.errors import DiscordAPIError, ForbiddenError, RateLimitError
 from vaidcord.gateway_runtime import GatewayRuntime
 from vaidcord.router import Router
 from vaidcord.types import (
@@ -295,6 +296,9 @@ class Bot(Router):
             avatar=data.get("avatar"),
             banner=data.get("banner"),
             accent_color=data.get("accent_color"),
+            avatar_decoration_data=data.get("avatar_decoration_data"),
+            collectibles=data.get("collectibles"),
+            primary_guild=data.get("primary_guild"),
         )
 
     def _parse_guild(self, data: dict[str, Any]) -> Guild:
@@ -458,7 +462,7 @@ class Bot(Router):
                 "send_message requires at least one of content/embeds/components/"
                 "sticker_ids/message_reference"
             )
-        return await self.api_client.send_message(channel_id, payload)
+        return await self.request("POST", f"/channels/{channel_id}/messages", json=payload)
 
     async def reply(
         self,
@@ -478,6 +482,60 @@ class Bot(Router):
             allowed_mentions=allowed_mentions,
             message_reference=message_reference,
         )
+
+    async def send_dm(self, user_id: int, content: str, **kwargs: Any) -> Message:
+        """Open (or fetch) a DM channel with a user and send a message."""
+        try:
+            dm_channel = await self.request(
+                "POST",
+                "/users/@me/channels",
+                json={"recipient_id": str(user_id)},
+            )
+        except DiscordAPIError as exc:
+            if exc.status == 429:
+                raise RateLimitError(
+                    "Rate limited while opening DM channel",
+                    retry_after=0.0,
+                    global_limit=False,
+                    raw_data=exc.raw_data,
+                ) from exc
+            if exc.status == 403:
+                raise ForbiddenError(
+                    "Cannot open DM channel. User may have DMs disabled or no shared server/permissions.",
+                    raw_data=exc.raw_data,
+                ) from exc
+            raise
+
+        channel_id = int(dm_channel["id"])
+        try:
+            message_data = await self.send_message(
+                channel_id=channel_id,
+                content=content,
+                **kwargs,
+            )
+        except DiscordAPIError as exc:
+            if exc.status == 429:
+                raise RateLimitError(
+                    "Rate limited while sending DM message",
+                    retry_after=0.0,
+                    global_limit=False,
+                    raw_data=exc.raw_data,
+                ) from exc
+            if exc.status == 403:
+                raise ForbiddenError(
+                    "Cannot send DM. User may have DMs disabled or no shared server/permissions.",
+                    raw_data=exc.raw_data,
+                ) from exc
+            raise
+
+        message = self._parse_message(message_data)
+        self._channels[message.channel.id] = message.channel
+        self._users[message.author.id] = message.author
+        return message
+
+    async def send_message_to_user(self, user_id: int, content: str, **kwargs: Any) -> Message:
+        """Alias for send_dm for semantic readability."""
+        return await self.send_dm(user_id=user_id, content=content, **kwargs)
 
     async def send_poll(
         self,
@@ -589,6 +647,40 @@ class Bot(Router):
         user = self._parse_user(data)
         self._users[user.id] = user
         return user
+
+    async def get_current_user(self) -> User:
+        """Get the current bot user via REST."""
+        data = await self.api_client.get_current_user()
+        user = self._parse_user(data)
+        self._users[user.id] = user
+        self._user = user
+        return user
+
+    async def modify_current_user(self, **payload: Any) -> User:
+        """Modify the current user settings (username/avatar/banner)."""
+        data = await self.api_client.modify_current_user(payload)
+        user = self._parse_user(data)
+        self._users[user.id] = user
+        self._user = user
+        return user
+
+    async def get_current_user_guilds(self, **params: Any) -> list[Guild]:
+        """Get current user guild list (/users/@me/guilds)."""
+        data = await self.api_client.get_current_user_guilds(**params)
+        guilds = [self._parse_guild(item) for item in data]
+        for guild in guilds:
+            self._guilds[guild.id] = guild
+        return guilds
+
+    async def get_current_user_guild_member(self, guild_id: int) -> dict[str, Any]:
+        """Get current user guild member object for a guild."""
+        return await self.api_client.get_current_user_guild_member(guild_id)
+
+    async def leave_guild(self, guild_id: int) -> dict[str, Any]:
+        """Leave a guild as current user."""
+        result = await self.api_client.leave_guild(guild_id)
+        self._guilds.pop(guild_id, None)
+        return result
 
     def run(self) -> None:
         """Run the bot (blocking)."""

--- a/vaidcord-py/src/vaidcord/gateway_runtime.py
+++ b/vaidcord-py/src/vaidcord/gateway_runtime.py
@@ -39,7 +39,8 @@ class GatewayRuntime:
         self._bot._state = BotState.CONNECTING
         gateway_info = await self._bot.api_client.request("GET", "/gateway/bot")
         ws_url = gateway_info.get("url", self._bot.config.gateway_url)
-        self._ws = await self._bot._create_session().ws_connect(
+        session = await self._bot._create_session()
+        self._ws = await session.ws_connect(
             f"{ws_url}?v={self._bot.config.api_version}&encoding=json"
         )
 

--- a/vaidcord-py/src/vaidcord/mock/server.py
+++ b/vaidcord-py/src/vaidcord/mock/server.py
@@ -22,6 +22,7 @@ class MockDiscordServer:
 
     def __post_init__(self) -> None:
         self._app.router.add_get("/api/v10/gateway/bot", self._gateway_bot)
+        self._app.router.add_post("/api/v10/users/@me/channels", self._create_dm)
         self._app.router.add_post("/api/v10/channels/{channel_id}/messages", self._send_message)
 
     async def _gateway_bot(self, request: web.Request) -> web.Response:
@@ -31,7 +32,23 @@ class MockDiscordServer:
     async def _send_message(self, request: web.Request) -> web.Response:
         payload = await request.json()
         self.requests.append({"method": "POST", "path": str(request.rel_url), "json": payload})
-        return web.json_response({"id": "mock-msg", **payload})
+        channel_id = request.match_info["channel_id"]
+        return web.json_response(
+            {
+                "id": "10001",
+                "channel_id": channel_id,
+                "content": payload.get("content", ""),
+                "tts": payload.get("tts", False),
+                "timestamp": "2026-04-30T00:00:00Z",
+                "author": {"id": "1", "username": "MockBot", "discriminator": "0", "bot": True},
+            }
+        )
+
+    async def _create_dm(self, request: web.Request) -> web.Response:
+        payload = await request.json()
+        self.requests.append({"method": "POST", "path": str(request.rel_url), "json": payload})
+        recipient_id = payload.get("recipient_id", "0")
+        return web.json_response({"id": str(int(recipient_id) + 1000), "type": 1})
 
     async def start(self) -> None:
         self._runner = web.AppRunner(self._app)

--- a/vaidcord-py/src/vaidcord/types/__init__.py
+++ b/vaidcord-py/src/vaidcord/types/__init__.py
@@ -73,6 +73,9 @@ class User:
     avatar: str | None = None
     banner: str | None = None
     accent_color: int | None = None
+    avatar_decoration_data: dict[str, Any] | None = None
+    collectibles: dict[str, Any] | None = None
+    primary_guild: dict[str, Any] | None = None
 
     @property
     def mention(self) -> str:

--- a/vaidcord-py/tests/test_bot.py
+++ b/vaidcord-py/tests/test_bot.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import pytest
 
 from vaidcord.bot import Bot, BotState, GatewayIntent
+from vaidcord.errors import DiscordAPIError, ForbiddenError
 from vaidcord.types import Channel, ChannelType, Message, User
 
 
@@ -198,7 +199,7 @@ async def test_connect_gateway_uses_gateway_bot(monkeypatch: pytest.MonkeyPatch)
         return {"url": "wss://gateway.discord.gg"}
 
     monkeypatch.setattr(bot, "_create_session", fake_create_session)
-    monkeypatch.setattr(bot, "request", fake_request)
+    monkeypatch.setattr(bot.api_client, "request", fake_request)
 
     await bot._connect_gateway()
     assert calls == [("GET", "/gateway/bot")]
@@ -262,3 +263,86 @@ async def test_message_answer_calls_send_message(
     response = await msg.answer("plain", embeds=[{"title": "x"}])
     assert calls == [(777, "plain")]
     assert response["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_dm_success_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """send_dm should open DM channel first and then send message."""
+    bot = Bot(token="test-token")
+    calls: list[tuple[str, str, dict]] = []
+
+    async def fake_request(method: str, endpoint: str, **kwargs):
+        calls.append((method, endpoint, kwargs))
+        return {"id": "999", "type": 1}
+
+    async def fake_send_message(channel_id: int, content: str | None = None, **kwargs):
+        assert channel_id == 999
+        assert content == "hello dm"
+        assert kwargs["embeds"] == [{"title": "DM"}]
+        return {
+            "id": "12345",
+            "channel_id": str(channel_id),
+            "content": content,
+            "timestamp": "2026-04-30T00:00:00Z",
+            "author": {"id": "42", "username": "bot", "discriminator": "0", "bot": True},
+        }
+
+    monkeypatch.setattr(bot, "request", fake_request)
+    monkeypatch.setattr(bot, "send_message", fake_send_message)
+
+    message = await bot.send_dm(user_id=777, content="hello dm", embeds=[{"title": "DM"}])
+    assert message.channel.id == 999
+    assert message.content == "hello dm"
+    assert calls == [
+        ("POST", "/users/@me/channels", {"json": {"recipient_id": "777"}}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_dm_open_channel_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """send_dm should map 403 opening DM channel to ForbiddenError."""
+    bot = Bot(token="test-token")
+
+    async def fake_request(method: str, endpoint: str, **kwargs):
+        raise DiscordAPIError("Forbidden", status=403, code=50007)
+
+    monkeypatch.setattr(bot, "request", fake_request)
+
+    with pytest.raises(ForbiddenError):
+        await bot.send_dm(user_id=111, content="hi")
+
+
+@pytest.mark.asyncio
+async def test_send_message_to_user_alias_forwards_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """send_message_to_user should proxy to send_dm and preserve kwargs."""
+    bot = Bot(token="test-token")
+    calls: list[tuple[int, str, dict]] = []
+
+    async def fake_send_dm(user_id: int, content: str, **kwargs):
+        calls.append((user_id, content, kwargs))
+        return Message(
+            id=1,
+            channel=Channel(id=2, type=ChannelType.DM),
+            author=User(id=3, username="bot", discriminator="0", bot=True),
+            content=content,
+            timestamp=datetime.now(),
+            bot=bot,
+        )
+
+    monkeypatch.setattr(bot, "send_dm", fake_send_dm)
+
+    await bot.send_message_to_user(
+        user_id=1234,
+        content="payload",
+        embeds=[{"title": "E"}],
+        components=[{"type": 1, "components": []}],
+    )
+    assert calls == [
+        (
+            1234,
+            "payload",
+            {"embeds": [{"title": "E"}], "components": [{"type": 1, "components": []}]},
+        )
+    ]

--- a/vaidcord-py/tests/test_mock.py
+++ b/vaidcord-py/tests/test_mock.py
@@ -220,3 +220,27 @@ async def test_mock_discord_server_smoke():
                 assert payload["content"] == "hello"
     finally:
         await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_mock_discord_server_send_dm_flow():
+    from vaidcord.bot import Bot, BotConfig
+    from vaidcord.mock import MockDiscordServer
+
+    server = MockDiscordServer(port=18082)
+    await server.start()
+    try:
+        bot = Bot(
+            config=BotConfig(
+                token="test-token",
+                base_url=server.base_url,
+                api_version="10",
+            )
+        )
+        message = await bot.send_dm(user_id=123, content="hello from test")
+        assert message.content == "hello from test"
+        assert server.requests[0]["path"] == "/api/v10/users/@me/channels"
+        assert server.requests[1]["path"] == "/api/v10/channels/1123/messages"
+        await bot.api_client.close()
+    finally:
+        await server.stop()


### PR DESCRIPTION
### Motivation

- Provide a convenience API to open a DM channel and send direct messages to a user by ID and expose some missing current-user REST helpers. 
- Ensure the mock server and test-suite can exercise DM flows end-to-end.

### Description

- Added `Bot.send_dm` and alias `send_message_to_user` which create/lookup a DM channel and send a message, with error mapping to `ForbiddenError` and `RateLimitError`. 
- Added several `/users/@me` helpers to `APIClient` (`get_current_user`, `modify_current_user`, `get_current_user_guilds`, `get_current_user_guild_member`, `leave_guild`, `create_dm`) and corresponding `Bot` wrappers (`get_current_user`, `modify_current_user`, `get_current_user_guilds`, `get_current_user_guild_member`, `leave_guild`).
- Expanded `User` type with `avatar_decoration_data`, `collectibles`, and `primary_guild` fields and updated user parsing accordingly. 
- Updated `Bot.send_message` to use `request` (direct REST request) and adjusted gateway session creation in `GatewayRuntime.connect` to re-use the created session for `ws_connect`. 
- Extended `MockDiscordServer` with a DM creation route (`POST /api/v10/users/@me/channels`) and improved message response payloads. 
- Added example `examples/send_dm_to_user.py` and README docs describing `Bot.send_dm` usage, and added/updated tests to cover DM flows and mock server behavior.

### Testing

- Ran the test-suite covering the modified areas, specifically `tests/test_bot.py` (including `test_send_dm_success_flow`, `test_send_dm_open_channel_error`, and `test_send_message_to_user_alias_forwards_kwargs`) and `tests/test_mock.py` (including `test_mock_discord_server_send_dm_flow`), and they all passed. 
- Performed the existing mock server smoke test `test_mock_discord_server_smoke` which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ba713614832a82adb14e22ae5e4d)