### PR TITLE
Expand mock Discord REST API and local UI

### DIFF
--- a/vaidcord-py/src/vaidcord/api_client.py
+++ b/vaidcord-py/src/vaidcord/api_client.py
@@ -42,14 +42,58 @@ class APIClient:
     async def send_message(self, channel_id: int, payload: dict[str, Any]) -> dict[str, Any]:
         return await self.post(f"/channels/{channel_id}/messages", json=payload)
 
+    async def list_messages(
+        self,
+        channel_id: int,
+        *,
+        limit: int = 50,
+        before: int | None = None,
+        after: int | None = None,
+        around: int | None = None,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        if before is not None:
+            params["before"] = before
+        if after is not None:
+            params["after"] = after
+        if around is not None:
+            params["around"] = around
+        return await self.get(f"/channels/{channel_id}/messages", params=params)  # type: ignore[return-value]
+
+    async def fetch_message(self, channel_id: int, message_id: int) -> dict[str, Any]:
+        return await self.get(f"/channels/{channel_id}/messages/{message_id}")
+
+    async def edit_message(
+        self,
+        channel_id: int,
+        message_id: int,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.patch(
+            f"/channels/{channel_id}/messages/{message_id}",
+            json=payload,
+        )
+
+    async def delete_message(self, channel_id: int, message_id: int) -> dict[str, Any]:
+        return await self.delete(f"/channels/{channel_id}/messages/{message_id}")
+
     async def trigger_typing(self, channel_id: int) -> dict[str, Any]:
         return await self.post(f"/channels/{channel_id}/typing")
 
     async def fetch_channel(self, channel_id: int) -> dict[str, Any]:
         return await self.get(f"/channels/{channel_id}")
 
+    async def modify_channel(self, channel_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self.patch(f"/channels/{channel_id}", json=payload)
+
+    async def delete_channel(self, channel_id: int) -> dict[str, Any]:
+        return await self.delete(f"/channels/{channel_id}")
+
     async def fetch_guild(self, guild_id: int) -> dict[str, Any]:
         return await self.get(f"/guilds/{guild_id}")
+
+    async def list_guild_channels(self, guild_id: int) -> list[dict[str, Any]]:
+        return await self.get(f"/guilds/{guild_id}/channels")  # type: ignore[return-value]
 
     async def fetch_user(self, user_id: int) -> dict[str, Any]:
         return await self.get(f"/users/{user_id}")

--- a/vaidcord-py/src/vaidcord/bot.py
+++ b/vaidcord-py/src/vaidcord/bot.py
@@ -646,6 +646,39 @@ class Bot(Router):
         """Trigger a typing indicator in a channel."""
         await self.api_client.trigger_typing(channel_id)
 
+    async def list_messages(
+        self,
+        channel_id: int,
+        *,
+        limit: int = 50,
+        before: int | None = None,
+        after: int | None = None,
+        around: int | None = None,
+    ) -> list[Message]:
+        """List and parse messages for a channel."""
+        items = await self.api_client.list_messages(
+            channel_id,
+            limit=limit,
+            before=before,
+            after=after,
+            around=around,
+        )
+        return [self._parse_message(item) for item in items]
+
+    async def fetch_message(self, channel_id: int, message_id: int) -> Message:
+        """Fetch and parse a single message from a channel."""
+        data = await self.api_client.fetch_message(channel_id, message_id)
+        return self._parse_message(data)
+
+    async def edit_message(self, channel_id: int, message_id: int, **payload: Any) -> Message:
+        """Edit a previously sent message."""
+        data = await self.api_client.edit_message(channel_id, message_id, payload)
+        return self._parse_message(data)
+
+    async def delete_message(self, channel_id: int, message_id: int) -> dict[str, Any]:
+        """Delete a message and clear it from the local cache path if present."""
+        return await self.api_client.delete_message(channel_id, message_id)
+
     async def delete_webhook(self, *, drop_pending_updates: bool = False) -> dict[str, Any]:
         """Compatibility helper for aiogram-like startup flows."""
         if "discord.com/api" in self.config.base_url:
@@ -708,12 +741,33 @@ class Bot(Router):
         self._channels[channel.id] = channel
         return channel
 
+    async def modify_channel(self, channel_id: int, **payload: Any) -> Channel:
+        """Modify and parse a channel from the API."""
+        data = await self.api_client.modify_channel(channel_id, payload)
+        channel = self._parse_channel(data)
+        self._channels[channel.id] = channel
+        return channel
+
+    async def delete_channel(self, channel_id: int) -> dict[str, Any]:
+        """Delete a channel and clear it from the local cache."""
+        result = await self.api_client.delete_channel(channel_id)
+        self._channels.pop(channel_id, None)
+        return result
+
     async def fetch_guild(self, guild_id: int) -> Guild:
         """Fetch and parse a guild from the API."""
         data = await self.api_client.fetch_guild(guild_id)
         guild = self._parse_guild(data)
         self._guilds[guild.id] = guild
         return guild
+
+    async def list_guild_channels(self, guild_id: int) -> list[Channel]:
+        """List and parse guild channels from the API."""
+        items = await self.api_client.list_guild_channels(guild_id)
+        channels = [self._parse_channel(item) for item in items]
+        for channel in channels:
+            self._channels[channel.id] = channel
+        return channels
 
     async def fetch_user(self, user_id: int) -> User:
         """Fetch and parse a user from the API."""

--- a/vaidcord-py/src/vaidcord/bot.py
+++ b/vaidcord-py/src/vaidcord/bot.py
@@ -391,6 +391,12 @@ class Bot(Router):
             if ts_str
             else datetime.now()
         )
+        edited_ts_str = data.get("edited_timestamp")
+        edited_timestamp = (
+            datetime.fromisoformat(edited_ts_str.replace("Z", "+00:00"))
+            if edited_ts_str
+            else None
+        )
 
         # Parse channel
         channel_id = int(data["channel_id"])
@@ -416,6 +422,7 @@ class Bot(Router):
             author=author,
             content=data.get("content", ""),
             timestamp=timestamp,
+            edited_timestamp=edited_timestamp,
             tts=data.get("tts", False),
             mention_everyone=data.get("mention_everyone", False),
             mentions=mentions,

--- a/vaidcord-py/src/vaidcord/mock/http.py
+++ b/vaidcord-py/src/vaidcord/mock/http.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from datetime import datetime
 from typing import Any
+
+from vaidcord.errors import create_discord_error
 
 from .config import MockSettings
 from .types import MockHTTPResponse
@@ -60,6 +61,8 @@ class MockHTTPClient:
                 "code": response.error_code or response.status,
                 "message": response.error_message or "Mock error",
             }
-            raise Exception(f"Mock HTTP Error {response.status}: {json.dumps(error_data)}")
+            if response.status == 429 and "retry_after" not in error_data:
+                error_data["retry_after"] = response.headers.get("Retry-After")
+            raise create_discord_error(response.status, error_data)
 
         return response.data

--- a/vaidcord-py/src/vaidcord/mock/server.py
+++ b/vaidcord-py/src/vaidcord/mock/server.py
@@ -11,6 +11,10 @@ from vaidcord.mock.ui import MOCK_UI_HTML
 logger = logging.getLogger(__name__)
 
 
+def _copy_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items()}
+
+
 @dataclass
 class MockDiscordServer:
     """Aiohttp-based mock Discord server for integration tests and local testing."""
@@ -24,70 +28,423 @@ class MockDiscordServer:
     _site: web.TCPSite | None = field(default=None, init=False)
     requests: list[dict[str, Any]] = field(default_factory=list, init=False)
     messages: list[dict[str, Any]] = field(default_factory=list, init=False)
+    typing_events: list[dict[str, Any]] = field(default_factory=list, init=False)
+    users: dict[str, dict[str, Any]] = field(default_factory=dict, init=False)
+    channels: dict[str, dict[str, Any]] = field(default_factory=dict, init=False)
+    guilds: dict[str, dict[str, Any]] = field(default_factory=dict, init=False)
+    _messages_by_id: dict[str, dict[str, Any]] = field(default_factory=dict, init=False)
+    _current_user: dict[str, Any] = field(default_factory=dict, init=False)
 
     def __post_init__(self) -> None:
+        self._seed_state()
         self._app.router.add_get("/", self._ui)
         self._app.router.add_get("/api/mock/state", self._mock_state)
         self._app.router.add_post("/api/mock/messages", self._mock_message)
+        self._app.router.add_post("/api/mock/reset", self._mock_reset)
+
         self._app.router.add_get("/api/v10/gateway/bot", self._gateway_bot)
+        self._app.router.add_get("/api/v10/users/@me", self._get_current_user)
+        self._app.router.add_get("/api/v10/users/{user_id}", self._get_user)
+        self._app.router.add_get("/api/v10/users/@me/guilds", self._list_current_user_guilds)
+        self._app.router.add_get("/api/v10/guilds/{guild_id}", self._get_guild)
+        self._app.router.add_get(
+            "/api/v10/guilds/{guild_id}/channels",
+            self._list_guild_channels,
+        )
         self._app.router.add_post("/api/v10/users/@me/channels", self._create_dm)
-        self._app.router.add_post("/api/v10/channels/{channel_id}/messages", self._send_message)
+
+        self._app.router.add_get("/api/v10/channels/{channel_id}", self._get_channel)
+        self._app.router.add_patch("/api/v10/channels/{channel_id}", self._edit_channel)
+        self._app.router.add_delete("/api/v10/channels/{channel_id}", self._delete_channel)
+        self._app.router.add_get(
+            "/api/v10/channels/{channel_id}/messages",
+            self._list_messages,
+        )
+        self._app.router.add_post(
+            "/api/v10/channels/{channel_id}/messages",
+            self._send_message,
+        )
+        self._app.router.add_get(
+            "/api/v10/channels/{channel_id}/messages/{message_id}",
+            self._get_message,
+        )
+        self._app.router.add_patch(
+            "/api/v10/channels/{channel_id}/messages/{message_id}",
+            self._edit_message,
+        )
+        self._app.router.add_delete(
+            "/api/v10/channels/{channel_id}/messages/{message_id}",
+            self._delete_message,
+        )
+        self._app.router.add_post(
+            "/api/v10/channels/{channel_id}/typing",
+            self._trigger_typing,
+        )
+
+    def _seed_state(self) -> None:
+        self.requests = []
+        self.messages = []
+        self.typing_events = []
+        self._messages_by_id = {}
+        self._current_user = {
+            "id": "1",
+            "username": "MockBot",
+            "discriminator": "0",
+            "bot": True,
+        }
+        self.users = {
+            "1": _copy_payload(self._current_user),
+            "2": {
+                "id": "2",
+                "username": "MockUser",
+                "discriminator": "0",
+                "bot": False,
+            },
+        }
+        self.guilds = {
+            "999": {
+                "id": "999",
+                "name": "Mock Guild",
+                "owner": True,
+                "owner_id": "1",
+                "features": [],
+                "member_count": 2,
+            }
+        }
+        self.channels = {
+            "123": {
+                "id": "123",
+                "type": 0,
+                "name": "general",
+                "topic": "Mock Discord workspace",
+                "guild_id": "999",
+            }
+        }
+
+    def _record_request(
+        self,
+        request: web.Request,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        entry: dict[str, Any] = {"method": request.method, "path": str(request.rel_url)}
+        if payload is not None:
+            entry["json"] = payload
+        self.requests.append(entry)
+
+    def _ensure_user(
+        self,
+        user_id: str,
+        *,
+        username: str | None = None,
+        bot: bool = False,
+    ) -> dict[str, Any]:
+        existing = self.users.get(user_id)
+        if existing is not None:
+            if username:
+                existing["username"] = username
+            existing["bot"] = bot
+            return existing
+        user = {
+            "id": user_id,
+            "username": username or f"User{user_id}",
+            "discriminator": "0",
+            "bot": bot,
+        }
+        self.users[user_id] = user
+        return user
+
+    def _ensure_guild(self, guild_id: str, *, name: str | None = None) -> dict[str, Any]:
+        existing = self.guilds.get(guild_id)
+        if existing is not None:
+            if name:
+                existing["name"] = name
+            return existing
+        guild = {
+            "id": guild_id,
+            "name": name or f"Guild {guild_id}",
+            "owner": False,
+            "owner_id": "1",
+            "features": [],
+            "member_count": len(self.users),
+        }
+        self.guilds[guild_id] = guild
+        return guild
+
+    def _ensure_channel(
+        self,
+        channel_id: str,
+        *,
+        channel_type: int = 0,
+        name: str | None = None,
+        guild_id: str | None = None,
+    ) -> dict[str, Any]:
+        existing = self.channels.get(channel_id)
+        if existing is not None:
+            if name:
+                existing["name"] = name
+            if guild_id is not None:
+                existing["guild_id"] = guild_id
+            return existing
+        channel = {
+            "id": channel_id,
+            "type": channel_type,
+            "name": name or f"channel-{channel_id}",
+        }
+        if guild_id is not None:
+            channel["guild_id"] = guild_id
+        self.channels[channel_id] = channel
+        return channel
 
     async def _ui(self, request: web.Request) -> web.Response:
         if not self.enable_ui:
             raise web.HTTPNotFound
-        self.requests.append({"method": "GET", "path": str(request.rel_url)})
+        self._record_request(request)
         return web.Response(text=MOCK_UI_HTML, content_type="text/html")
 
     async def _mock_state(self, request: web.Request) -> web.Response:
-        self.requests.append({"method": "GET", "path": str(request.rel_url)})
+        self._record_request(request)
         return web.json_response(
             {
                 "base_url": self.base_url,
                 "gateway_url": self.gateway_url,
+                "current_user": self._current_user,
                 "requests": self.requests,
                 "messages": self.messages,
+                "typing_events": self.typing_events,
+                "users": list(self.users.values()),
+                "channels": list(self.channels.values()),
+                "guilds": list(self.guilds.values()),
             }
         )
 
+    async def _mock_reset(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        self._seed_state()
+        return web.json_response({"ok": True})
+
     async def _mock_message(self, request: web.Request) -> web.Response:
         payload = await request.json()
-        self.requests.append({"method": "POST", "path": str(request.rel_url), "json": payload})
+        self._record_request(request, payload=payload)
+        channel_id = str(payload.get("channel_id", "123"))
+        guild_id = payload.get("guild_id")
+        guild_name = payload.get("guild_name")
+        channel_name = payload.get("channel_name")
+        author_id = str(payload.get("author_id", "2"))
+        author_name = str(payload.get("author_username", "MockUser"))
+        author_bot = bool(payload.get("author_bot", False))
+
+        if guild_id is not None:
+            self._ensure_guild(str(guild_id), name=str(guild_name) if guild_name else None)
+        self._ensure_channel(
+            channel_id,
+            channel_type=1 if guild_id is None and channel_id.startswith("dm-") else 0,
+            name=str(channel_name) if channel_name else None,
+            guild_id=str(guild_id) if guild_id is not None else None,
+        )
+        author = self._ensure_user(author_id, username=author_name, bot=author_bot)
         message = self._build_message(
-            channel_id=str(payload.get("channel_id", "123")),
+            channel_id=channel_id,
             content=str(payload.get("content", "")),
-            author={
-                "id": str(payload.get("author_id", "2")),
-                "username": str(payload.get("author_username", "MockUser")),
-                "discriminator": "0",
-                "bot": bool(payload.get("author_bot", False)),
-            },
+            author=author,
+            guild_id=str(guild_id) if guild_id is not None else None,
         )
         self.messages.append(message)
+        self._messages_by_id[message["id"]] = message
         return web.json_response(message)
 
     async def _gateway_bot(self, request: web.Request) -> web.Response:
-        self.requests.append({"method": "GET", "path": str(request.rel_url)})
+        self._record_request(request)
         return web.json_response({"url": self.gateway_url, "shards": 1})
+
+    async def _get_current_user(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        return web.json_response(self._current_user)
+
+    async def _get_user(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        user_id = request.match_info["user_id"]
+        user = self.users.get(user_id)
+        if user is None:
+            raise web.HTTPNotFound(text='{"message":"Unknown User","code":10013}')
+        return web.json_response(user)
+
+    async def _list_current_user_guilds(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        return web.json_response(list(self.guilds.values()))
+
+    async def _get_guild(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        guild_id = request.match_info["guild_id"]
+        guild = self.guilds.get(guild_id)
+        if guild is None:
+            raise web.HTTPNotFound(text='{"message":"Unknown Guild","code":10004}')
+        return web.json_response(guild)
+
+    async def _list_guild_channels(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        guild_id = request.match_info["guild_id"]
+        guild = self.guilds.get(guild_id)
+        if guild is None:
+            raise web.HTTPNotFound(text='{"message":"Unknown Guild","code":10004}')
+        channels = [channel for channel in self.channels.values() if channel.get("guild_id") == guild_id]
+        return web.json_response(channels)
+
+    async def _get_channel(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        channel_id = request.match_info["channel_id"]
+        channel = self.channels.get(channel_id)
+        if channel is None:
+            raise web.HTTPNotFound(text='{"message":"Unknown Channel","code":10003}')
+        return web.json_response(channel)
+
+    async def _edit_channel(self, request: web.Request) -> web.Response:
+        payload = await request.json()
+        self._record_request(request, payload=payload)
+        channel_id = request.match_info["channel_id"]
+        channel = self.channels.get(channel_id)
+        if channel is None:
+            raise web.HTTPNotFound(text='{"message":"Unknown Channel","code":10003}')
+        for key in ("name", "topic", "position", "nsfw"):
+            if key in payload:
+                channel[key] = payload[key]
+        return web.json_response(channel)
+
+    async def _delete_channel(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        channel_id = request.match_info["channel_id"]
+        channel = self.channels.pop(channel_id, None)
+        if channel is None:
+            raise web.HTTPNotFound(text='{"message":"Unknown Channel","code":10003}')
+        removed_ids = {
+            message["id"] for message in self.messages if message["channel_id"] == channel_id
+        }
+        self.messages = [message for message in self.messages if message["channel_id"] != channel_id]
+        self.typing_events = [
+            event for event in self.typing_events if event["channel_id"] != channel_id
+        ]
+        for message_id in removed_ids:
+            self._messages_by_id.pop(message_id, None)
+        return web.json_response(channel)
+
+    async def _list_messages(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        channel_id = request.match_info["channel_id"]
+        limit = int(request.query.get("limit", "50"))
+        messages = [msg for msg in self.messages if msg["channel_id"] == channel_id]
+        before = request.query.get("before")
+        after = request.query.get("after")
+        around = request.query.get("around")
+        if before is not None:
+            messages = [msg for msg in messages if int(msg["id"]) < int(before)]
+        if after is not None:
+            messages = [msg for msg in messages if int(msg["id"]) > int(after)]
+        if around is not None:
+            center_index = next(
+                (index for index, msg in enumerate(messages) if msg["id"] == around),
+                None,
+            )
+            if center_index is None:
+                messages = []
+            else:
+                radius = max(1, limit // 2)
+                start = max(0, center_index - radius)
+                stop = center_index + radius + 1
+                messages = messages[start:stop]
+        return web.json_response(list(reversed(messages[-limit:])))
+
+    async def _get_message(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        channel_id = request.match_info["channel_id"]
+        message_id = request.match_info["message_id"]
+        message = self._messages_by_id.get(message_id)
+        if message is None or message["channel_id"] != channel_id:
+            raise web.HTTPNotFound(text='{"message":"Unknown Message","code":10008}')
+        return web.json_response(message)
 
     async def _send_message(self, request: web.Request) -> web.Response:
         payload = await request.json()
-        self.requests.append({"method": "POST", "path": str(request.rel_url), "json": payload})
+        self._record_request(request, payload=payload)
         channel_id = request.match_info["channel_id"]
+        channel = self.channels.get(channel_id)
+        if channel is None:
+            channel = self._ensure_channel(channel_id)
         message = self._build_message(
             channel_id=channel_id,
             content=str(payload.get("content", "")),
             tts=bool(payload.get("tts", False)),
-            author={"id": "1", "username": "MockBot", "discriminator": "0", "bot": True},
+            author=self._current_user,
+            guild_id=channel.get("guild_id"),
         )
+        if "embeds" in payload:
+            message["embeds"] = payload["embeds"]
+        if "components" in payload:
+            message["components"] = payload["components"]
+        if "flags" in payload:
+            message["flags"] = payload["flags"]
+        if "message_reference" in payload:
+            message["message_reference"] = payload["message_reference"]
+        if "poll" in payload:
+            message["poll"] = payload["poll"]
         self.messages.append(message)
+        self._messages_by_id[message["id"]] = message
         return web.json_response(message)
+
+    async def _edit_message(self, request: web.Request) -> web.Response:
+        payload = await request.json()
+        self._record_request(request, payload=payload)
+        channel_id = request.match_info["channel_id"]
+        message_id = request.match_info["message_id"]
+        message = self._messages_by_id.get(message_id)
+        if message is None or message["channel_id"] != channel_id:
+            raise web.HTTPNotFound(text='{"message":"Unknown Message","code":10008}')
+        for key in ("content", "embeds", "components", "flags"):
+            if key in payload:
+                message[key] = payload[key]
+        return web.json_response(message)
+
+    async def _delete_message(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        channel_id = request.match_info["channel_id"]
+        message_id = request.match_info["message_id"]
+        message = self._messages_by_id.get(message_id)
+        if message is None or message["channel_id"] != channel_id:
+            raise web.HTTPNotFound(text='{"message":"Unknown Message","code":10008}')
+        self.messages = [item for item in self.messages if item["id"] != message_id]
+        self._messages_by_id.pop(message_id, None)
+        return web.Response(status=204)
+
+    async def _trigger_typing(self, request: web.Request) -> web.Response:
+        self._record_request(request)
+        channel_id = request.match_info["channel_id"]
+        channel = self.channels.get(channel_id)
+        if channel is None:
+            self._ensure_channel(channel_id)
+        self.typing_events.append(
+            {
+                "channel_id": channel_id,
+                "user_id": self._current_user["id"],
+                "username": self._current_user["username"],
+            }
+        )
+        return web.Response(status=204)
 
     async def _create_dm(self, request: web.Request) -> web.Response:
         payload = await request.json()
-        self.requests.append({"method": "POST", "path": str(request.rel_url), "json": payload})
-        recipient_id = payload.get("recipient_id", "0")
-        return web.json_response({"id": str(int(recipient_id) + 1000), "type": 1})
+        self._record_request(request, payload=payload)
+        recipient_id = str(payload.get("recipient_id", "0"))
+        recipient = self._ensure_user(recipient_id)
+        try:
+            channel_id = str(int(recipient_id) + 1000)
+        except ValueError:
+            channel_id = f"dm-{recipient_id}"
+        channel = self._ensure_channel(
+            channel_id,
+            channel_type=1,
+            name=f"dm-{recipient['username']}",
+        )
+        channel["recipients"] = [recipient]
+        return web.json_response({"id": channel_id, "type": 1, "recipients": [recipient]})
 
     def _build_message(
         self,
@@ -95,16 +452,20 @@ class MockDiscordServer:
         channel_id: str,
         content: str,
         author: dict[str, Any],
+        guild_id: str | None = None,
         tts: bool = False,
     ) -> dict[str, Any]:
-        return {
+        message = {
             "id": str(10000 + len(self.messages) + 1),
             "channel_id": channel_id,
             "content": content,
             "tts": tts,
             "timestamp": "2026-04-30T00:00:00Z",
-            "author": author,
+            "author": _copy_payload(author),
         }
+        if guild_id is not None:
+            message["guild_id"] = guild_id
+        return message
 
     async def start(self) -> None:
         self._runner = web.AppRunner(self._app)

--- a/vaidcord-py/src/vaidcord/mock/server.py
+++ b/vaidcord-py/src/vaidcord/mock/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 
 from aiohttp import web
@@ -13,6 +14,10 @@ logger = logging.getLogger(__name__)
 
 def _copy_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in payload.items()}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 @dataclass
@@ -40,6 +45,9 @@ class MockDiscordServer:
         self._app.router.add_get("/", self._ui)
         self._app.router.add_get("/api/mock/state", self._mock_state)
         self._app.router.add_post("/api/mock/messages", self._mock_message)
+        self._app.router.add_post("/api/mock/profiles", self._create_profile)
+        self._app.router.add_patch("/api/mock/profiles/{user_id}", self._update_profile)
+        self._app.router.add_patch("/api/mock/current-user", self._set_current_user)
         self._app.router.add_post("/api/mock/reset", self._mock_reset)
 
         self._app.router.add_get("/api/v10/gateway/bot", self._gateway_bot)
@@ -132,27 +140,56 @@ class MockDiscordServer:
             entry["json"] = payload
         self.requests.append(entry)
 
+    def _sync_guild_member_counts(self) -> None:
+        member_count = len(self.users)
+        for guild in self.guilds.values():
+            guild["member_count"] = member_count
+
     def _ensure_user(
         self,
         user_id: str,
         *,
         username: str | None = None,
         bot: bool = False,
+        discriminator: str | None = None,
+        global_name: str | None = None,
     ) -> dict[str, Any]:
         existing = self.users.get(user_id)
         if existing is not None:
             if username:
                 existing["username"] = username
             existing["bot"] = bot
+            if discriminator is not None:
+                existing["discriminator"] = discriminator
+            if global_name is not None:
+                existing["global_name"] = global_name
             return existing
         user = {
             "id": user_id,
             "username": username or f"User{user_id}",
-            "discriminator": "0",
+            "discriminator": discriminator or "0",
             "bot": bot,
         }
+        if global_name is not None:
+            user["global_name"] = global_name
         self.users[user_id] = user
+        self._sync_guild_member_counts()
         return user
+
+    def _upsert_profile(self, user_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        profile = self._ensure_user(
+            user_id,
+            username=str(payload.get("username") or f"User{user_id}"),
+            bot=bool(payload.get("bot", False)),
+            discriminator=str(payload.get("discriminator", "0")),
+            global_name=(
+                str(payload["global_name"]) if payload.get("global_name") is not None else None
+            ),
+        )
+        if "global_name" in payload and payload.get("global_name") in ("", None):
+            profile.pop("global_name", None)
+        self._sync_guild_member_counts()
+        return profile
 
     def _ensure_guild(self, guild_id: str, *, name: str | None = None) -> dict[str, Any]:
         existing = self.guilds.get(guild_id)
@@ -252,6 +289,36 @@ class MockDiscordServer:
         self.messages.append(message)
         self._messages_by_id[message["id"]] = message
         return web.json_response(message)
+
+    async def _create_profile(self, request: web.Request) -> web.Response:
+        payload = await request.json()
+        self._record_request(request, payload=payload)
+        user_id = str(payload.get("id") or len(self.users) + 1)
+        profile = self._upsert_profile(user_id, payload)
+        if payload.get("set_current"):
+            self._current_user = profile
+        return web.json_response(profile)
+
+    async def _update_profile(self, request: web.Request) -> web.Response:
+        payload = await request.json()
+        self._record_request(request, payload=payload)
+        user_id = request.match_info["user_id"]
+        if user_id not in self.users:
+            raise web.HTTPNotFound(text='{"message":"Unknown User","code":10013}')
+        updated = self._upsert_profile(user_id, {**self.users[user_id], **payload})
+        if self._current_user["id"] == user_id:
+            self._current_user = updated
+        return web.json_response(updated)
+
+    async def _set_current_user(self, request: web.Request) -> web.Response:
+        payload = await request.json()
+        self._record_request(request, payload=payload)
+        user_id = str(payload.get("user_id", ""))
+        user = self.users.get(user_id)
+        if user is None:
+            raise web.HTTPNotFound(text='{"message":"Unknown User","code":10013}')
+        self._current_user = user
+        return web.json_response(user)
 
     async def _gateway_bot(self, request: web.Request) -> web.Response:
         self._record_request(request)
@@ -401,6 +468,7 @@ class MockDiscordServer:
         for key in ("content", "embeds", "components", "flags"):
             if key in payload:
                 message[key] = payload[key]
+        message["edited_timestamp"] = _utc_now_iso()
         return web.json_response(message)
 
     async def _delete_message(self, request: web.Request) -> web.Response:
@@ -425,6 +493,7 @@ class MockDiscordServer:
                 "channel_id": channel_id,
                 "user_id": self._current_user["id"],
                 "username": self._current_user["username"],
+                "timestamp": _utc_now_iso(),
             }
         )
         return web.Response(status=204)
@@ -460,7 +529,8 @@ class MockDiscordServer:
             "channel_id": channel_id,
             "content": content,
             "tts": tts,
-            "timestamp": "2026-04-30T00:00:00Z",
+            "timestamp": _utc_now_iso(),
+            "edited_timestamp": None,
             "author": _copy_payload(author),
         }
         if guild_id is not None:

--- a/vaidcord-py/src/vaidcord/mock/ui.py
+++ b/vaidcord-py/src/vaidcord/mock/ui.py
@@ -10,37 +10,44 @@ MOCK_UI_HTML = """<!doctype html>
   <style>
     :root {
       color-scheme: dark;
-      --bg: #050505;
-      --panel: #101114;
-      --panel-soft: #17191f;
-      --line: #252834;
-      --text: #f4f6fb;
-      --muted: #9ba3b4;
-      --accent: #5865f2;
-      --green: #23a55a;
-      --danger: #ed4245;
+      --bg: #0b1020;
+      --bg-soft: #131a2e;
+      --panel: #111827;
+      --panel-2: #0f172a;
+      --line: #26314f;
+      --text: #edf2ff;
+      --muted: #9fb0d2;
+      --accent: #4f7cff;
+      --accent-soft: rgba(79, 124, 255, 0.14);
+      --green: #1fa971;
+      --green-soft: rgba(31, 169, 113, 0.16);
+      --red: #d95c5c;
+      --yellow: #f0b429;
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       min-height: 100vh;
-      background: var(--bg);
+      background:
+        radial-gradient(circle at top right, rgba(79, 124, 255, 0.18), transparent 28%),
+        linear-gradient(180deg, #0b1020 0%, #090d19 100%);
       color: var(--text);
-      font: 14px/1.45 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font: 14px/1.45 "Segoe UI", Inter, ui-sans-serif, system-ui, sans-serif;
     }
     .shell {
       display: grid;
-      grid-template-columns: 280px minmax(0, 1fr);
+      grid-template-columns: 248px minmax(0, 1fr);
       min-height: 100vh;
     }
     aside {
-      border-right: 1px solid var(--line);
-      background: #090a0d;
       padding: 20px;
+      border-right: 1px solid var(--line);
+      background: rgba(9, 14, 28, 0.94);
+      backdrop-filter: blur(12px);
     }
     main {
       display: grid;
-      grid-template-rows: auto minmax(0, 1fr) auto;
+      grid-template-rows: auto auto minmax(0, 1fr);
       min-width: 0;
     }
     .brand {
@@ -48,24 +55,24 @@ MOCK_UI_HTML = """<!doctype html>
       align-items: center;
       gap: 10px;
       font-weight: 700;
-      letter-spacing: 0;
+      font-size: 15px;
     }
     .mark {
-      width: 32px;
-      height: 32px;
-      border-radius: 8px;
+      width: 34px;
+      height: 34px;
+      border-radius: 10px;
       display: grid;
       place-items: center;
-      background: var(--accent);
+      background: linear-gradient(135deg, #4f7cff, #6e58ff);
       color: white;
       font-weight: 800;
     }
-    .status {
-      margin-top: 24px;
-      padding: 12px;
+    .status-card, .quick-card {
+      margin-top: 18px;
+      padding: 14px;
       border: 1px solid var(--line);
-      border-radius: 8px;
-      background: var(--panel);
+      border-radius: 10px;
+      background: rgba(17, 24, 39, 0.86);
     }
     .pill {
       display: inline-flex;
@@ -73,8 +80,8 @@ MOCK_UI_HTML = """<!doctype html>
       gap: 8px;
       border-radius: 999px;
       padding: 4px 10px;
-      background: rgba(35, 165, 90, .16);
-      color: #8df0b7;
+      background: var(--green-soft);
+      color: #8ef0c1;
       font-size: 12px;
       font-weight: 700;
     }
@@ -84,88 +91,165 @@ MOCK_UI_HTML = """<!doctype html>
       border-radius: 50%;
       background: var(--green);
     }
-    .meta {
-      margin-top: 14px;
-      color: var(--muted);
+    .meta, .quick-stats {
+      margin-top: 12px;
       display: grid;
       gap: 8px;
+      color: var(--muted);
       word-break: break-word;
+      font-size: 13px;
     }
     header {
-      padding: 18px 24px;
-      border-bottom: 1px solid var(--line);
-      background: var(--panel);
       display: flex;
       justify-content: space-between;
+      gap: 18px;
       align-items: center;
-      gap: 16px;
+      padding: 18px 24px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(15, 23, 42, 0.82);
+      backdrop-filter: blur(10px);
     }
     h1 {
       margin: 0;
-      font-size: 18px;
-      line-height: 1.2;
-      letter-spacing: 0;
+      font-size: 20px;
     }
     .sub {
+      margin-top: 4px;
       color: var(--muted);
-      margin-top: 3px;
       font-size: 13px;
+    }
+    .toolbar {
+      display: flex;
+      gap: 10px;
+    }
+    button {
+      border: 1px solid transparent;
+      border-radius: 10px;
+      font: inherit;
+      cursor: pointer;
+      color: white;
+      background: var(--accent);
+      padding: 10px 14px;
+      font-weight: 700;
+    }
+    button.secondary {
+      background: transparent;
+      border-color: var(--line);
+      color: var(--text);
+    }
+    .composer {
+      display: grid;
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+      gap: 12px;
+      padding: 18px 24px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(13, 18, 33, 0.78);
+    }
+    .field {
+      display: grid;
+      gap: 6px;
+      min-width: 0;
+    }
+    .field.wide {
+      grid-column: span 2;
+    }
+    .field.full {
+      grid-column: 1 / -1;
+    }
+    .field label {
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    input {
+      width: 100%;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 11px 12px;
+      min-width: 0;
+      background: var(--panel);
+      color: var(--text);
+      font: inherit;
+    }
+    .actions {
+      display: flex;
+      gap: 10px;
+      align-items: end;
     }
     .workspace {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) 360px;
+      grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.9fr) minmax(320px, 1fr);
       min-height: 0;
     }
-    .messages, .requests {
-      padding: 20px 24px;
+    .column {
+      min-width: 0;
+      border-right: 1px solid var(--line);
       overflow: auto;
     }
-    .requests {
-      border-left: 1px solid var(--line);
-      background: #08090b;
+    .column:last-child { border-right: 0; }
+    .section {
+      padding: 18px 20px;
+      border-bottom: 1px solid var(--line);
     }
-    .message, .request {
-      background: var(--panel-soft);
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      padding: 12px;
-      margin-bottom: 10px;
+    .section h2 {
+      margin: 0 0 12px;
+      font-size: 14px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--muted);
     }
-    .message strong, .request strong { color: white; }
-    .body { margin-top: 6px; color: #dfe3ee; white-space: pre-wrap; }
-    .small { color: var(--muted); font-size: 12px; }
-    form {
+    .stack {
       display: grid;
-      grid-template-columns: minmax(120px, 180px) minmax(0, 1fr) auto;
       gap: 10px;
-      padding: 16px 24px;
-      border-top: 1px solid var(--line);
-      background: var(--panel);
     }
-    input, button {
-      height: 40px;
-      border-radius: 8px;
+    .card {
       border: 1px solid var(--line);
-      font: inherit;
+      border-radius: 10px;
+      background: rgba(17, 24, 39, 0.82);
+      padding: 12px;
     }
-    input {
-      background: #06070a;
-      color: var(--text);
-      padding: 0 12px;
-      min-width: 0;
-    }
-    button {
-      background: var(--accent);
+    .card strong {
       color: white;
-      border-color: transparent;
-      padding: 0 18px;
-      font-weight: 700;
-      cursor: pointer;
     }
-    @media (max-width: 860px) {
-      .shell, .workspace { grid-template-columns: 1fr; }
-      aside, .requests { border-right: 0; border-left: 0; border-bottom: 1px solid var(--line); }
-      form { grid-template-columns: 1fr; }
+    .small {
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .body {
+      margin-top: 6px;
+      color: #dfe8ff;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: 11px;
+      font-weight: 700;
+      margin-left: 8px;
+      background: var(--accent-soft);
+      color: #b7c7ff;
+    }
+    .warn {
+      color: var(--yellow);
+    }
+    @media (max-width: 1180px) {
+      .shell { grid-template-columns: 1fr; }
+      aside { border-right: 0; border-bottom: 1px solid var(--line); }
+      .composer { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .workspace { grid-template-columns: 1fr; }
+      .column { border-right: 0; border-bottom: 1px solid var(--line); }
+    }
+    @media (max-width: 700px) {
+      header { display: grid; }
+      .composer { grid-template-columns: 1fr; }
+      .field.wide, .field.full { grid-column: auto; }
+      .actions { align-items: stretch; }
+      .actions button { flex: 1; }
     }
   </style>
 </head>
@@ -173,12 +257,22 @@ MOCK_UI_HTML = """<!doctype html>
   <div class="shell">
     <aside>
       <div class="brand"><div class="mark">V</div><div>VaidCord Mock Server</div></div>
-      <div class="status">
-        <span class="pill"><span class="dot"></span> Online</span>
+      <div class="status-card">
+        <span class="pill"><span class="dot"></span> Local Gateway Ready</span>
         <div class="meta">
           <div>REST base: <span id="base-url">-</span></div>
           <div>Gateway: <span id="gateway-url">-</span></div>
+          <div>Bot user: <span id="current-user">-</span></div>
+        </div>
+      </div>
+      <div class="quick-card">
+        <div class="small">Quick Stats</div>
+        <div class="quick-stats">
           <div>Requests: <span id="request-count">0</span></div>
+          <div>Messages: <span id="message-count">0</span></div>
+          <div>Typing: <span id="typing-count">0</span></div>
+          <div>Channels: <span id="channel-count">0</span></div>
+          <div>Guilds: <span id="guild-count">0</span></div>
         </div>
       </div>
     </aside>
@@ -186,26 +280,116 @@ MOCK_UI_HTML = """<!doctype html>
       <header>
         <div>
           <h1>Mock Discord Workspace</h1>
-          <div class="sub">Send test messages and inspect bot API calls locally.</div>
+          <div class="sub">Simulate inbound traffic, inspect REST calls, and keep bot testing close to real Discord flows.</div>
+        </div>
+        <div class="toolbar">
+          <button class="secondary" id="refresh-btn" type="button">Refresh</button>
+          <button class="secondary" id="reset-btn" type="button">Reset State</button>
         </div>
       </header>
-      <section class="workspace">
-        <div class="messages" id="messages"></div>
-        <div class="requests" id="requests"></div>
+      <section class="composer">
+        <div class="field">
+          <label for="channel-id">Channel ID</label>
+          <input id="channel-id" value="123" aria-label="Channel ID">
+        </div>
+        <div class="field">
+          <label for="channel-name">Channel Name</label>
+          <input id="channel-name" value="general" aria-label="Channel Name">
+        </div>
+        <div class="field">
+          <label for="guild-id">Guild ID</label>
+          <input id="guild-id" value="999" aria-label="Guild ID">
+        </div>
+        <div class="field">
+          <label for="guild-name">Guild Name</label>
+          <input id="guild-name" value="Mock Guild" aria-label="Guild Name">
+        </div>
+        <div class="field">
+          <label for="author-id">Author ID</label>
+          <input id="author-id" value="2" aria-label="Author ID">
+        </div>
+        <div class="field">
+          <label for="author-name">Author Name</label>
+          <input id="author-name" value="MockUser" aria-label="Author Name">
+        </div>
+        <div class="field full">
+          <label for="content">Simulated inbound message</label>
+          <input id="content" placeholder="Type the message content the bot should receive" aria-label="Message content">
+        </div>
+        <div class="field full actions">
+          <button id="send-btn" type="button">Simulate Message</button>
+          <button id="send-bot-btn" class="secondary" type="button">Send Bot Message</button>
+          <button id="typing-btn" class="secondary" type="button">Trigger Typing</button>
+        </div>
+        <div class="field">
+          <label for="channel-topic">Channel Topic</label>
+          <input id="channel-topic" placeholder="Optional topic for channel edits" aria-label="Channel Topic">
+        </div>
+        <div class="field full actions">
+          <button id="save-channel-btn" class="secondary" type="button">Save Channel</button>
+        </div>
+        <div class="field">
+          <label for="message-id">Message ID</label>
+          <input id="message-id" placeholder="Select a message card or enter an id" aria-label="Message ID">
+        </div>
+        <div class="field wide">
+          <label for="message-edit-content">Edited Message Content</label>
+          <input id="message-edit-content" placeholder="Edit the selected message" aria-label="Edited Message Content">
+        </div>
+        <div class="field full actions">
+          <button id="edit-message-btn" class="secondary" type="button">Edit Message</button>
+          <button id="delete-message-btn" class="secondary" type="button">Delete Message</button>
+        </div>
       </section>
-      <form id="send-form">
-        <input id="channel-id" value="123" aria-label="Channel ID">
-        <input id="content" placeholder="Message content" aria-label="Message content">
-        <button type="submit">Send</button>
-      </form>
+      <section class="workspace">
+        <div class="column">
+          <div class="section">
+            <h2>Messages</h2>
+            <div class="stack" id="messages"></div>
+          </div>
+          <div class="section">
+            <h2>Typing Events</h2>
+            <div class="stack" id="typing"></div>
+          </div>
+        </div>
+        <div class="column">
+          <div class="section">
+            <h2>Users</h2>
+            <div class="stack" id="users"></div>
+          </div>
+          <div class="section">
+            <h2>Channels</h2>
+            <div class="stack" id="channels"></div>
+          </div>
+          <div class="section">
+            <h2>Guilds</h2>
+            <div class="stack" id="guilds"></div>
+          </div>
+        </div>
+        <div class="column">
+          <div class="section">
+            <h2>REST Requests</h2>
+            <div class="stack" id="requests"></div>
+          </div>
+        </div>
+      </section>
     </main>
   </div>
   <script>
     const messages = document.getElementById("messages");
     const requests = document.getElementById("requests");
+    const users = document.getElementById("users");
+    const channels = document.getElementById("channels");
+    const guilds = document.getElementById("guilds");
+    const typing = document.getElementById("typing");
     const baseUrl = document.getElementById("base-url");
     const gatewayUrl = document.getElementById("gateway-url");
+    const currentUser = document.getElementById("current-user");
     const requestCount = document.getElementById("request-count");
+    const messageCount = document.getElementById("message-count");
+    const typingCount = document.getElementById("typing-count");
+    const channelCount = document.getElementById("channel-count");
+    const guildCount = document.getElementById("guild-count");
 
     function escapeHtml(value) {
       return String(value).replace(/[&<>"']/g, (char) => ({
@@ -213,43 +397,202 @@ MOCK_UI_HTML = """<!doctype html>
       }[char]));
     }
 
+    function renderCards(target, items, emptyText, formatter) {
+      target.innerHTML = items.map(formatter).join("") || `<div class="small">${emptyText}</div>`;
+    }
+
     async function refresh() {
       const response = await fetch("/api/mock/state");
       const state = await response.json();
+
       baseUrl.textContent = state.base_url;
       gatewayUrl.textContent = state.gateway_url;
+      currentUser.textContent = `${state.current_user.username} (${state.current_user.id})`;
+
       requestCount.textContent = state.requests.length;
-      messages.innerHTML = state.messages.map((message) => `
-        <article class="message">
+      messageCount.textContent = state.messages.length;
+      typingCount.textContent = state.typing_events.length;
+      channelCount.textContent = state.channels.length;
+      guildCount.textContent = state.guilds.length;
+
+      renderCards(messages, [...state.messages].reverse(), "No messages yet.", (message) => `
+        <article
+          class="card"
+          data-message-id="${escapeHtml(message.id)}"
+          data-message-content="${escapeHtml(message.content || "")}"
+          data-channel-id="${escapeHtml(message.channel_id)}"
+        >
           <strong>${escapeHtml(message.author.username)}</strong>
-          <span class="small">#${escapeHtml(message.channel_id)} - ${escapeHtml(message.id)}</span>
-          <div class="body">${escapeHtml(message.content)}</div>
+          <span class="badge">${escapeHtml(message.channel_id)}</span>
+          ${message.guild_id ? `<span class="badge">${escapeHtml(message.guild_id)}</span>` : ""}
+          <div class="small">${escapeHtml(message.id)}</div>
+          <div class="body">${escapeHtml(message.content || "(empty message)")}</div>
         </article>
-      `).join("") || '<div class="small">No messages yet.</div>';
-      requests.innerHTML = state.requests.slice().reverse().map((request) => `
-        <article class="request">
+      `);
+
+      renderCards(typing, [...state.typing_events].reverse(), "No typing events yet.", (entry) => `
+        <article class="card">
+          <strong>${escapeHtml(entry.username)}</strong>
+          <span class="badge">${escapeHtml(entry.channel_id)}</span>
+          <div class="small">user_id=${escapeHtml(entry.user_id)}</div>
+        </article>
+      `);
+
+      renderCards(users, state.users, "No users in state.", (user) => `
+        <article class="card">
+          <strong>${escapeHtml(user.username)}</strong>
+          ${user.bot ? '<span class="badge">bot</span>' : ""}
+          <div class="small">${escapeHtml(user.id)}</div>
+        </article>
+      `);
+
+      renderCards(channels, state.channels, "No channels in state.", (channel) => `
+        <article
+          class="card"
+          data-channel-id="${escapeHtml(channel.id)}"
+          data-channel-name="${escapeHtml(channel.name || "")}"
+          data-channel-topic="${escapeHtml(channel.topic || "")}"
+          data-guild-id="${escapeHtml(channel.guild_id || "")}"
+        >
+          <strong>${escapeHtml(channel.name || "unnamed channel")}</strong>
+          <span class="badge">type=${escapeHtml(channel.type)}</span>
+          <div class="small">id=${escapeHtml(channel.id)}${channel.guild_id ? ` · guild=${escapeHtml(channel.guild_id)}` : ' · DM'}</div>
+          ${channel.topic ? `<div class="body">${escapeHtml(channel.topic)}</div>` : ""}
+        </article>
+      `);
+
+      renderCards(guilds, state.guilds, "No guilds in state.", (guild) => `
+        <article class="card">
+          <strong>${escapeHtml(guild.name)}</strong>
+          <div class="small">id=${escapeHtml(guild.id)} · members=${escapeHtml(guild.member_count ?? 0)}</div>
+        </article>
+      `);
+
+      renderCards(requests, [...state.requests].reverse(), "No API calls yet.", (request) => `
+        <article class="card">
           <strong>${escapeHtml(request.method)}</strong>
-          <span class="small">${escapeHtml(request.path)}</span>
+          <span class="badge">${escapeHtml(request.path)}</span>
           <div class="body">${escapeHtml(JSON.stringify(request.json || {}, null, 2))}</div>
         </article>
-      `).join("") || '<div class="small">No API calls yet.</div>';
+      `);
+
+      messages.querySelectorAll("[data-message-id]").forEach((node) => {
+        node.addEventListener("click", () => {
+          document.getElementById("message-id").value = node.getAttribute("data-message-id") || "";
+          document.getElementById("message-edit-content").value = node.getAttribute("data-message-content") || "";
+          document.getElementById("channel-id").value = node.getAttribute("data-channel-id") || "123";
+        });
+      });
+
+      channels.querySelectorAll("[data-channel-id]").forEach((node) => {
+        node.addEventListener("click", () => {
+          document.getElementById("channel-id").value = node.getAttribute("data-channel-id") || "123";
+          document.getElementById("channel-name").value = node.getAttribute("data-channel-name") || "";
+          document.getElementById("channel-topic").value = node.getAttribute("data-channel-topic") || "";
+          const guildId = node.getAttribute("data-guild-id");
+          if (guildId) {
+            document.getElementById("guild-id").value = guildId;
+          }
+        });
+      });
     }
 
-    document.getElementById("send-form").addEventListener("submit", async (event) => {
-      event.preventDefault();
-      const channelId = document.getElementById("channel-id").value || "123";
-      const content = document.getElementById("content").value;
+    async function simulateMessage() {
       await fetch("/api/mock/messages", {
         method: "POST",
         headers: {"Content-Type": "application/json"},
-        body: JSON.stringify({channel_id: channelId, content})
+        body: JSON.stringify({
+          channel_id: document.getElementById("channel-id").value || "123",
+          channel_name: document.getElementById("channel-name").value || "general",
+          guild_id: document.getElementById("guild-id").value || "999",
+          guild_name: document.getElementById("guild-name").value || "Mock Guild",
+          author_id: document.getElementById("author-id").value || "2",
+          author_username: document.getElementById("author-name").value || "MockUser",
+          content: document.getElementById("content").value
+        })
       });
       document.getElementById("content").value = "";
       await refresh();
-    });
+    }
+
+    async function sendBotMessage() {
+      const channelId = document.getElementById("channel-id").value || "123";
+      await fetch(`/api/v10/channels/${encodeURIComponent(channelId)}/messages`, {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({
+          content: document.getElementById("content").value
+        })
+      });
+      document.getElementById("content").value = "";
+      await refresh();
+    }
+
+    async function triggerTyping() {
+      const channelId = document.getElementById("channel-id").value || "123";
+      await fetch(`/api/v10/channels/${encodeURIComponent(channelId)}/typing`, {
+        method: "POST"
+      });
+      await refresh();
+    }
+
+    async function saveChannel() {
+      const channelId = document.getElementById("channel-id").value || "123";
+      await fetch(`/api/v10/channels/${encodeURIComponent(channelId)}`, {
+        method: "PATCH",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({
+          name: document.getElementById("channel-name").value,
+          topic: document.getElementById("channel-topic").value
+        })
+      });
+      await refresh();
+    }
+
+    async function editMessage() {
+      const channelId = document.getElementById("channel-id").value || "123";
+      const messageId = document.getElementById("message-id").value;
+      if (!messageId) return;
+      await fetch(`/api/v10/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}`, {
+        method: "PATCH",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({
+          content: document.getElementById("message-edit-content").value
+        })
+      });
+      await refresh();
+    }
+
+    async function deleteMessage() {
+      const channelId = document.getElementById("channel-id").value || "123";
+      const messageId = document.getElementById("message-id").value;
+      if (!messageId) return;
+      await fetch(`/api/v10/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}`, {
+        method: "DELETE"
+      });
+      document.getElementById("message-id").value = "";
+      document.getElementById("message-edit-content").value = "";
+      await refresh();
+    }
+
+    async function resetState() {
+      await fetch("/api/mock/reset", {method: "POST"});
+      document.getElementById("message-id").value = "";
+      document.getElementById("message-edit-content").value = "";
+      await refresh();
+    }
+
+    document.getElementById("send-btn").addEventListener("click", simulateMessage);
+    document.getElementById("send-bot-btn").addEventListener("click", sendBotMessage);
+    document.getElementById("typing-btn").addEventListener("click", triggerTyping);
+    document.getElementById("save-channel-btn").addEventListener("click", saveChannel);
+    document.getElementById("edit-message-btn").addEventListener("click", editMessage);
+    document.getElementById("delete-message-btn").addEventListener("click", deleteMessage);
+    document.getElementById("refresh-btn").addEventListener("click", refresh);
+    document.getElementById("reset-btn").addEventListener("click", resetState);
 
     refresh();
-    setInterval(refresh, 1500);
+    setInterval(refresh, 1800);
   </script>
 </body>
 </html>

--- a/vaidcord-py/src/vaidcord/mock/ui.py
+++ b/vaidcord-py/src/vaidcord/mock/ui.py
@@ -262,7 +262,7 @@ MOCK_UI_HTML = """<!doctype html>
         <div class="meta">
           <div>REST base: <span id="base-url">-</span></div>
           <div>Gateway: <span id="gateway-url">-</span></div>
-          <div>Bot user: <span id="current-user">-</span></div>
+          <div>Active bot: <span id="current-user">-</span></div>
         </div>
       </div>
       <div class="quick-card">
@@ -273,6 +273,13 @@ MOCK_UI_HTML = """<!doctype html>
           <div>Typing: <span id="typing-count">0</span></div>
           <div>Channels: <span id="channel-count">0</span></div>
           <div>Guilds: <span id="guild-count">0</span></div>
+        </div>
+      </div>
+      <div class="quick-card">
+        <div class="small">Bot Profile</div>
+        <div class="field" style="margin-top: 10px;">
+          <label for="current-user-select">Send as</label>
+          <input id="current-user-select" list="profile-options" aria-label="Active bot profile">
         </div>
       </div>
     </aside>
@@ -312,6 +319,10 @@ MOCK_UI_HTML = """<!doctype html>
           <label for="author-name">Author Name</label>
           <input id="author-name" value="MockUser" aria-label="Author Name">
         </div>
+        <div class="field">
+          <label for="author-bot">Author Is Bot</label>
+          <input id="author-bot" type="checkbox" aria-label="Author Is Bot">
+        </div>
         <div class="field full">
           <label for="content">Simulated inbound message</label>
           <input id="content" placeholder="Type the message content the bot should receive" aria-label="Message content">
@@ -339,6 +350,31 @@ MOCK_UI_HTML = """<!doctype html>
         <div class="field full actions">
           <button id="edit-message-btn" class="secondary" type="button">Edit Message</button>
           <button id="delete-message-btn" class="secondary" type="button">Delete Message</button>
+        </div>
+        <div class="field">
+          <label for="profile-id">Profile ID</label>
+          <input id="profile-id" placeholder="Leave blank to auto-create" aria-label="Profile ID">
+        </div>
+        <div class="field">
+          <label for="profile-name">Profile Name</label>
+          <input id="profile-name" placeholder="Profile username" aria-label="Profile Name">
+        </div>
+        <div class="field">
+          <label for="profile-global-name">Display Name</label>
+          <input id="profile-global-name" placeholder="Optional display name" aria-label="Display Name">
+        </div>
+        <div class="field">
+          <label for="profile-discriminator">Discriminator</label>
+          <input id="profile-discriminator" value="0" aria-label="Discriminator">
+        </div>
+        <div class="field">
+          <label for="profile-bot">Profile Is Bot</label>
+          <input id="profile-bot" type="checkbox" aria-label="Profile Is Bot">
+        </div>
+        <div class="field full actions">
+          <button id="create-profile-btn" class="secondary" type="button">Create Profile</button>
+          <button id="save-profile-btn" class="secondary" type="button">Save Profile</button>
+          <button id="set-current-profile-btn" class="secondary" type="button">Use As Bot</button>
         </div>
       </section>
       <section class="workspace">
@@ -375,6 +411,7 @@ MOCK_UI_HTML = """<!doctype html>
       </section>
     </main>
   </div>
+  <datalist id="profile-options"></datalist>
   <script>
     const messages = document.getElementById("messages");
     const requests = document.getElementById("requests");
@@ -390,11 +427,33 @@ MOCK_UI_HTML = """<!doctype html>
     const typingCount = document.getElementById("typing-count");
     const channelCount = document.getElementById("channel-count");
     const guildCount = document.getElementById("guild-count");
+    const currentUserSelect = document.getElementById("current-user-select");
+    const profileOptions = document.getElementById("profile-options");
 
     function escapeHtml(value) {
       return String(value).replace(/[&<>"']/g, (char) => ({
         "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#039;"
       }[char]));
+    }
+
+    function formatProfileValue(user) {
+      return `${user.id} | ${user.username}`;
+    }
+
+    function parseSelectedProfileId() {
+      const raw = currentUserSelect.value || "";
+      return raw.split("|")[0].trim();
+    }
+
+    function fillProfileForm(user) {
+      document.getElementById("profile-id").value = user.id || "";
+      document.getElementById("profile-name").value = user.username || "";
+      document.getElementById("profile-global-name").value = user.global_name || "";
+      document.getElementById("profile-discriminator").value = user.discriminator || "0";
+      document.getElementById("profile-bot").checked = Boolean(user.bot);
+      document.getElementById("author-id").value = user.id || "";
+      document.getElementById("author-name").value = user.username || "";
+      document.getElementById("author-bot").checked = Boolean(user.bot);
     }
 
     function renderCards(target, items, emptyText, formatter) {
@@ -408,6 +467,10 @@ MOCK_UI_HTML = """<!doctype html>
       baseUrl.textContent = state.base_url;
       gatewayUrl.textContent = state.gateway_url;
       currentUser.textContent = `${state.current_user.username} (${state.current_user.id})`;
+      currentUserSelect.value = formatProfileValue(state.current_user);
+      profileOptions.innerHTML = state.users.map((user) =>
+        `<option value="${escapeHtml(formatProfileValue(user))}"></option>`
+      ).join("");
 
       requestCount.textContent = state.requests.length;
       messageCount.textContent = state.messages.length;
@@ -426,6 +489,7 @@ MOCK_UI_HTML = """<!doctype html>
           <span class="badge">${escapeHtml(message.channel_id)}</span>
           ${message.guild_id ? `<span class="badge">${escapeHtml(message.guild_id)}</span>` : ""}
           <div class="small">${escapeHtml(message.id)}</div>
+          <div class="small">${escapeHtml(message.timestamp || "")}${message.edited_timestamp ? ` · edited ${escapeHtml(message.edited_timestamp)}` : ""}</div>
           <div class="body">${escapeHtml(message.content || "(empty message)")}</div>
         </article>
       `);
@@ -435,14 +499,22 @@ MOCK_UI_HTML = """<!doctype html>
           <strong>${escapeHtml(entry.username)}</strong>
           <span class="badge">${escapeHtml(entry.channel_id)}</span>
           <div class="small">user_id=${escapeHtml(entry.user_id)}</div>
+          <div class="small">${escapeHtml(entry.timestamp || "")}</div>
         </article>
       `);
 
       renderCards(users, state.users, "No users in state.", (user) => `
-        <article class="card">
+        <article
+          class="card"
+          data-user-id="${escapeHtml(user.id)}"
+          data-user-name="${escapeHtml(user.username || "")}"
+          data-user-global-name="${escapeHtml(user.global_name || "")}"
+          data-user-discriminator="${escapeHtml(user.discriminator || "0")}"
+          data-user-bot="${user.bot ? "1" : "0"}"
+        >
           <strong>${escapeHtml(user.username)}</strong>
           ${user.bot ? '<span class="badge">bot</span>' : ""}
-          <div class="small">${escapeHtml(user.id)}</div>
+          <div class="small">${escapeHtml(user.id)}${user.global_name ? ` · ${escapeHtml(user.global_name)}` : ""}</div>
         </article>
       `);
 
@@ -495,6 +567,18 @@ MOCK_UI_HTML = """<!doctype html>
           }
         });
       });
+
+      users.querySelectorAll("[data-user-id]").forEach((node) => {
+        node.addEventListener("click", () => {
+          fillProfileForm({
+            id: node.getAttribute("data-user-id") || "",
+            username: node.getAttribute("data-user-name") || "",
+            global_name: node.getAttribute("data-user-global-name") || "",
+            discriminator: node.getAttribute("data-user-discriminator") || "0",
+            bot: node.getAttribute("data-user-bot") === "1",
+          });
+        });
+      });
     }
 
     async function simulateMessage() {
@@ -508,6 +592,7 @@ MOCK_UI_HTML = """<!doctype html>
           guild_name: document.getElementById("guild-name").value || "Mock Guild",
           author_id: document.getElementById("author-id").value || "2",
           author_username: document.getElementById("author-name").value || "MockUser",
+          author_bot: document.getElementById("author-bot").checked,
           content: document.getElementById("content").value
         })
       });
@@ -582,12 +667,62 @@ MOCK_UI_HTML = """<!doctype html>
       await refresh();
     }
 
+    async function createProfile() {
+      const response = await fetch("/api/mock/profiles", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({
+          id: document.getElementById("profile-id").value || undefined,
+          username: document.getElementById("profile-name").value || "Profile",
+          global_name: document.getElementById("profile-global-name").value || null,
+          discriminator: document.getElementById("profile-discriminator").value || "0",
+          bot: document.getElementById("profile-bot").checked
+        })
+      });
+      const profile = await response.json();
+      fillProfileForm(profile);
+      await refresh();
+    }
+
+    async function saveProfile() {
+      const profileId = document.getElementById("profile-id").value;
+      if (!profileId) return;
+      const response = await fetch(`/api/mock/profiles/${encodeURIComponent(profileId)}`, {
+        method: "PATCH",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({
+          username: document.getElementById("profile-name").value || "Profile",
+          global_name: document.getElementById("profile-global-name").value || null,
+          discriminator: document.getElementById("profile-discriminator").value || "0",
+          bot: document.getElementById("profile-bot").checked
+        })
+      });
+      const profile = await response.json();
+      fillProfileForm(profile);
+      await refresh();
+    }
+
+    async function setCurrentProfile() {
+      const profileId = document.getElementById("profile-id").value || parseSelectedProfileId();
+      if (!profileId) return;
+      await fetch("/api/mock/current-user", {
+        method: "PATCH",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({user_id: profileId})
+      });
+      await refresh();
+    }
+
     document.getElementById("send-btn").addEventListener("click", simulateMessage);
     document.getElementById("send-bot-btn").addEventListener("click", sendBotMessage);
     document.getElementById("typing-btn").addEventListener("click", triggerTyping);
     document.getElementById("save-channel-btn").addEventListener("click", saveChannel);
     document.getElementById("edit-message-btn").addEventListener("click", editMessage);
     document.getElementById("delete-message-btn").addEventListener("click", deleteMessage);
+    document.getElementById("create-profile-btn").addEventListener("click", createProfile);
+    document.getElementById("save-profile-btn").addEventListener("click", saveProfile);
+    document.getElementById("set-current-profile-btn").addEventListener("click", setCurrentProfile);
+    currentUserSelect.addEventListener("change", setCurrentProfile);
     document.getElementById("refresh-btn").addEventListener("click", refresh);
     document.getElementById("reset-btn").addEventListener("click", resetState);
 

--- a/vaidcord-py/tests/test_mock.py
+++ b/vaidcord-py/tests/test_mock.py
@@ -1,5 +1,7 @@
 """Tests for VaidCord mock utilities."""
 
+from datetime import datetime
+
 import pytest
 
 from vaidcord import (
@@ -339,6 +341,8 @@ async def test_mock_discord_server_local_ui_and_state():
                 assert state["users"][-1]["username"] == "UI User"
                 assert state["guilds"][-1]["id"] == "777"
                 assert state["typing_events"][0]["channel_id"] == "456"
+                assert state["messages"][0]["timestamp"].endswith("Z")
+                datetime.fromisoformat(state["messages"][0]["timestamp"].replace("Z", "+00:00"))
                 assert len(state["requests"]) >= 4
     finally:
         await server.stop()
@@ -505,9 +509,11 @@ async def test_api_client_and_bot_message_channel_helpers_work_against_mock_serv
 
         edited = await bot.edit_message(123, fetched.id, content="edited second")
         assert edited.content == "edited second"
+        assert edited.edited_timestamp is not None
 
         raw_messages = await api.list_messages(123, after=10001)
         assert raw_messages[0]["content"] == "edited second"
+        assert raw_messages[0]["edited_timestamp"].endswith("Z")
 
         deleted = await bot.delete_message(123, fetched.id)
         assert deleted == {}
@@ -530,5 +536,59 @@ async def test_mock_discord_server_ui_can_be_disabled():
         async with aiohttp.ClientSession() as session:
             async with session.get(server.local_url) as resp:
                 assert resp.status == 404
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_mock_discord_server_profiles_can_be_created_updated_and_selected():
+    import aiohttp
+
+    from vaidcord.mock import MockDiscordServer
+
+    server = MockDiscordServer(port=0)
+    await server.start()
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{server.local_url}api/mock/profiles",
+                json={
+                    "id": "77",
+                    "username": "SupportBot",
+                    "global_name": "Support",
+                    "discriminator": "4242",
+                    "bot": True,
+                },
+            ) as resp:
+                assert resp.status == 200
+                created = await resp.json()
+                assert created["id"] == "77"
+                assert created["bot"] is True
+
+            async with session.patch(
+                f"{server.local_url}api/mock/profiles/77",
+                json={"username": "SupportAgent", "bot": False},
+            ) as resp:
+                assert resp.status == 200
+                updated = await resp.json()
+                assert updated["username"] == "SupportAgent"
+                assert updated["bot"] is False
+
+            async with session.patch(
+                f"{server.local_url}api/mock/current-user",
+                json={"user_id": "77"},
+            ) as resp:
+                assert resp.status == 200
+                current = await resp.json()
+                assert current["id"] == "77"
+
+            async with session.post(
+                f"{server.base_url}/v10/channels/123/messages",
+                json={"content": "sent as selected profile"},
+            ) as resp:
+                assert resp.status == 200
+                message = await resp.json()
+                assert message["author"]["id"] == "77"
+                assert message["author"]["username"] == "SupportAgent"
     finally:
         await server.stop()

--- a/vaidcord-py/tests/test_mock.py
+++ b/vaidcord-py/tests/test_mock.py
@@ -92,6 +92,43 @@ async def test_mock_http_client():
     assert history[0]["endpoint"] == "/users/123"
 
 
+@pytest.mark.asyncio
+async def test_mock_http_client_raises_vaidcord_errors():
+    """Mock HTTP errors should match the real client hierarchy."""
+    from vaidcord.errors import ForbiddenError, NotFoundError, RateLimitError
+    from vaidcord.mock import MockHTTPClient, MockHTTPResponse
+
+    http = MockHTTPClient()
+    http.set_response(
+        "GET",
+        "/forbidden",
+        MockHTTPResponse(status=403, error_message="forbidden"),
+    )
+    http.set_response(
+        "GET",
+        "/missing",
+        MockHTTPResponse(status=404, error_message="missing"),
+    )
+    http.set_response(
+        "GET",
+        "/limited",
+        MockHTTPResponse(
+            status=429,
+            error_message="limited",
+            headers={"Retry-After": "1.5"},
+        ),
+    )
+
+    with pytest.raises(ForbiddenError):
+        await http.request("GET", "/forbidden")
+
+    with pytest.raises(NotFoundError):
+        await http.request("GET", "/missing")
+
+    with pytest.raises(RateLimitError):
+        await http.request("GET", "/limited")
+
+
 def test_mock_bot_configure_runtime_settings():
     """MockBot.configure should allow easy runtime tuning."""
     bot = MockBot()
@@ -203,7 +240,7 @@ async def test_mock_discord_server_smoke():
 
     from vaidcord.mock import MockDiscordServer
 
-    server = MockDiscordServer(port=18081)
+    server = MockDiscordServer(port=0)
     await server.start()
     try:
         async with aiohttp.ClientSession() as session:
@@ -219,6 +256,19 @@ async def test_mock_discord_server_smoke():
                 assert resp.status == 200
                 payload = await resp.json()
                 assert payload["content"] == "hello"
+                message_id = payload["id"]
+
+            async with session.get(f"{server.base_url}/v10/channels/123") as resp:
+                assert resp.status == 200
+                channel = await resp.json()
+                assert channel["id"] == "123"
+
+            async with session.get(
+                f"{server.base_url}/v10/channels/123/messages/{message_id}"
+            ) as resp:
+                assert resp.status == 200
+                payload = await resp.json()
+                assert payload["id"] == message_id
     finally:
         await server.stop()
 
@@ -228,7 +278,7 @@ async def test_mock_discord_server_send_dm_flow():
     from vaidcord.bot import Bot, BotConfig
     from vaidcord.mock import MockDiscordServer
 
-    server = MockDiscordServer(port=18082)
+    server = MockDiscordServer(port=0)
     await server.start()
     try:
         bot = Bot(
@@ -263,19 +313,207 @@ async def test_mock_discord_server_local_ui_and_state():
 
             async with session.post(
                 f"{server.local_url}api/mock/messages",
-                json={"channel_id": "456", "content": "from ui"},
+                json={
+                    "channel_id": "456",
+                    "channel_name": "testing",
+                    "guild_id": "777",
+                    "guild_name": "UI Guild",
+                    "author_id": "9",
+                    "author_username": "UI User",
+                    "content": "from ui",
+                },
             ) as resp:
                 assert resp.status == 200
                 message = await resp.json()
                 assert message["content"] == "from ui"
-                assert message["author"]["username"] == "MockUser"
+                assert message["author"]["username"] == "UI User"
+
+            async with session.post(f"{server.base_url}/v10/channels/456/typing") as resp:
+                assert resp.status == 204
 
             async with session.get(f"{server.local_url}api/mock/state") as resp:
                 assert resp.status == 200
                 state = await resp.json()
                 assert state["base_url"] == server.base_url
                 assert state["messages"][0]["channel_id"] == "456"
-                assert len(state["requests"]) >= 3
+                assert state["users"][-1]["username"] == "UI User"
+                assert state["guilds"][-1]["id"] == "777"
+                assert state["typing_events"][0]["channel_id"] == "456"
+                assert len(state["requests"]) >= 4
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_mock_discord_server_supports_message_edit_delete_and_fetch_list():
+    import aiohttp
+
+    from vaidcord.mock import MockDiscordServer
+
+    server = MockDiscordServer(port=0)
+    await server.start()
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{server.base_url}/v10/channels/123/messages",
+                json={"content": "before edit"},
+            ) as resp:
+                assert resp.status == 200
+                created = await resp.json()
+
+            message_id = created["id"]
+            async with session.patch(
+                f"{server.base_url}/v10/channels/123/messages/{message_id}",
+                json={"content": "after edit"},
+            ) as resp:
+                assert resp.status == 200
+                edited = await resp.json()
+                assert edited["content"] == "after edit"
+
+            async with session.get(
+                f"{server.base_url}/v10/channels/123/messages"
+            ) as resp:
+                assert resp.status == 200
+                messages = await resp.json()
+                assert messages[0]["id"] == message_id
+
+            async with session.delete(
+                f"{server.base_url}/v10/channels/123/messages/{message_id}"
+            ) as resp:
+                assert resp.status == 204
+
+            async with session.get(
+                f"{server.base_url}/v10/channels/123/messages/{message_id}"
+            ) as resp:
+                assert resp.status == 404
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_mock_discord_server_exposes_common_rest_entities():
+    import aiohttp
+
+    from vaidcord.mock import MockDiscordServer
+
+    server = MockDiscordServer(port=0)
+    await server.start()
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{server.base_url}/v10/users/@me") as resp:
+                assert resp.status == 200
+                current_user = await resp.json()
+                assert current_user["username"] == "MockBot"
+
+            async with session.get(f"{server.base_url}/v10/users/2") as resp:
+                assert resp.status == 200
+                user = await resp.json()
+                assert user["username"] == "MockUser"
+
+            async with session.get(f"{server.base_url}/v10/guilds/999") as resp:
+                assert resp.status == 200
+                guild = await resp.json()
+                assert guild["name"] == "Mock Guild"
+
+            async with session.post(
+                f"{server.base_url}/v10/users/@me/channels",
+                json={"recipient_id": "55"},
+            ) as resp:
+                assert resp.status == 200
+                channel = await resp.json()
+                assert channel["id"] == "1055"
+                assert channel["type"] == 1
+                assert channel["recipients"][0]["id"] == "55"
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_mock_discord_server_supports_channel_lifecycle_and_guild_channel_listing():
+    import aiohttp
+
+    from vaidcord.mock import MockDiscordServer
+
+    server = MockDiscordServer(port=0)
+    await server.start()
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{server.base_url}/v10/users/@me/guilds") as resp:
+                assert resp.status == 200
+                guilds = await resp.json()
+                assert guilds[0]["id"] == "999"
+
+            async with session.get(f"{server.base_url}/v10/guilds/999/channels") as resp:
+                assert resp.status == 200
+                channels = await resp.json()
+                assert channels[0]["id"] == "123"
+
+            async with session.patch(
+                f"{server.base_url}/v10/channels/123",
+                json={"name": "ops-room", "topic": "updated topic"},
+            ) as resp:
+                assert resp.status == 200
+                channel = await resp.json()
+                assert channel["name"] == "ops-room"
+                assert channel["topic"] == "updated topic"
+
+            async with session.delete(f"{server.base_url}/v10/channels/123") as resp:
+                assert resp.status == 200
+                deleted = await resp.json()
+                assert deleted["id"] == "123"
+
+            async with session.get(f"{server.base_url}/v10/channels/123") as resp:
+                assert resp.status == 404
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_api_client_and_bot_message_channel_helpers_work_against_mock_server():
+    from vaidcord import Bot, BotConfig
+    from vaidcord.api_client import APIClient
+    from vaidcord.mock import MockDiscordServer
+
+    server = MockDiscordServer(port=0)
+    await server.start()
+    try:
+        api = APIClient(token="test-token", base_url=server.base_url, api_version="10")
+        bot = Bot(
+            config=BotConfig(
+                token="test-token",
+                base_url=server.base_url,
+                api_version="10",
+            )
+        )
+
+        channel = await bot.modify_channel(123, name="support", topic="triage")
+        assert channel.name == "support"
+        assert channel.topic == "triage"
+
+        guild_channels = await bot.list_guild_channels(999)
+        assert guild_channels[0].id == 123
+
+        await api.send_message(123, {"content": "first"})
+        await api.send_message(123, {"content": "second"})
+
+        listed = await bot.list_messages(123, limit=1)
+        assert len(listed) == 1
+        assert listed[0].content == "second"
+
+        fetched = await bot.fetch_message(123, listed[0].id)
+        assert fetched.content == "second"
+
+        edited = await bot.edit_message(123, fetched.id, content="edited second")
+        assert edited.content == "edited second"
+
+        raw_messages = await api.list_messages(123, after=10001)
+        assert raw_messages[0]["content"] == "edited second"
+
+        deleted = await bot.delete_message(123, fetched.id)
+        assert deleted == {}
+
+        await api.close()
+        await bot.api_client.close()
     finally:
         await server.stop()
 


### PR DESCRIPTION
## Summary

This PR expands the local Discord mock surface so common message and channel workflows can be exercised end-to-end without hitting real Discord, and adds matching helper methods to the Python client layer.

Closes #12.
Partially addresses #14.

## What Changed

- expanded `MockDiscordServer` with richer REST coverage for:
  - `GET /users/@me`
  - `GET /users/{user_id}`
  - `GET /users/@me/guilds`
  - `GET /guilds/{guild_id}`
  - `GET /guilds/{guild_id}/channels`
  - `GET /channels/{channel_id}`
  - `PATCH /channels/{channel_id}`
  - `DELETE /channels/{channel_id}`
  - `GET /channels/{channel_id}/messages`
  - `GET /channels/{channel_id}/messages/{message_id}`
  - `PATCH /channels/{channel_id}/messages/{message_id}`
  - `DELETE /channels/{channel_id}/messages/{message_id}`
  - `POST /channels/{channel_id}/typing`
- kept mock server state in sync across users, guilds, channels, messages, typing events, and message-id lookups
- expanded the browser UI so it can:
  - simulate inbound messages with guild/channel/author metadata
  - send bot-authored messages
  - trigger typing
  - edit channel name/topic
  - pick existing messages/channels from the UI
  - edit and delete messages from the UI
  - inspect requests, entities, typing events, and current mock state
- added `APIClient` helpers for message listing/fetch/edit/delete plus channel modify/delete and guild channel listing
- added matching `Bot` helpers for parsed message/channel workflows and channel cache updates
- updated `MockHTTPClient` to raise the same Vaidcord error hierarchy as the real client, including `retry_after` propagation for 429 responses
- added focused mock tests covering the new REST routes, UI-backed state flows, helper methods, and mock error mapping

## Why

Before this change, the mock layer was useful for basic smoke tests but still left a gap for realistic local testing of message lifecycle and channel-management flows. The client also exposed only a narrow subset of those routes, so developers had to fall back to raw requests for common operations.

This narrows that gap by making the mock server and helper layer move together.

## Validation

- Added targeted tests in `vaidcord-py/tests/test_mock.py` covering the new message, channel, guild-listing, UI-state, and error-mapping flows.
- In this container I could not run the full pytest suite because the environment is missing test dependencies and outbound package download is blocked, so runtime validation here is limited to code review plus the new test coverage added in-tree.
