### PR TITLE
ci(release): dispatch-mode tag creation and idempotent publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -137,12 +137,24 @@ jobs:
         run: |
           python -m twine check dist/*
 
+      - name: Resolve git reference for history
+        id: ref
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "ref=${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            # workflow_dispatch before the tag exists: use the built commit.
+            echo "ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate release card
         working-directory: .
         run: |
-          PREV=$(git describe --tags --abbrev=0 '${{ steps.meta.outputs.tag }}^' 2>/dev/null || echo "")
-          RANGE="${{ steps.meta.outputs.tag }}"
-          [ -n "$PREV" ] && RANGE="${PREV}..${{ steps.meta.outputs.tag }}"
+          REF='${{ steps.ref.outputs.ref }}'
+          PREV=$(git describe --tags --abbrev=0 "${REF}^" 2>/dev/null || echo "")
+          RANGE="$REF"
+          [ -n "$PREV" ] && RANGE="${PREV}..${REF}"
           COMMITS=$(git log --no-merges --oneline "$RANGE" -- vaidcord-py | wc -l | tr -d ' ')
           ARGS=()
           if [ -f vaidcord-py/.release-highlights ]; then
@@ -176,7 +188,7 @@ jobs:
           fi
           python .github/scripts/release_notes.py \
             --package vaidcord --version "${{ steps.meta.outputs.version }}" \
-            --tag "${{ steps.meta.outputs.tag }}" --language python \
+            --tag "${{ steps.ref.outputs.ref }}" --language python \
             --tag-pattern "v*" --tag-pattern "py-v*" --path vaidcord-py --path UNITED.md \
             --card-url "${{ steps.card.outputs.card-url }}" \
             "${ARGS[@]}" \
@@ -194,12 +206,14 @@ jobs:
             gh release edit "$TAG" --title "VAIDCORD-PY ${{ steps.meta.outputs.version }}" --notes-file release-notes.md "${FLAGS[@]}"
             gh release upload "$TAG" vaidcord-py/dist/* release-card.svg --clobber
           else
+            # --target creates the tag when it does not exist yet (dispatch mode).
             gh release create "$TAG" vaidcord-py/dist/* release-card.svg \
               --title "VAIDCORD-PY ${{ steps.meta.outputs.version }}" \
-              --notes-file release-notes.md --verify-tag "${FLAGS[@]}"
+              --notes-file release-notes.md --target "${GITHUB_SHA}" "${FLAGS[@]}"
           fi
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: vaidcord-py/dist
+          skip-existing: true

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -87,11 +87,22 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve git reference for history
+        id: ref
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "ref=${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate release card
         run: |
-          PREV=$(git tag --list 'vaidcord-go/v*' --sort=-creatordate --merged '${{ steps.meta.outputs.tag }}^' | grep -v "^${{ steps.meta.outputs.tag }}$" | head -1 || echo "")
-          RANGE="${{ steps.meta.outputs.tag }}"
-          [ -n "$PREV" ] && RANGE="${PREV}..${{ steps.meta.outputs.tag }}"
+          REF='${{ steps.ref.outputs.ref }}'
+          PREV=$(git tag --list 'vaidcord-go/v*' --sort=-creatordate --merged "${REF}^" 2>/dev/null | grep -v "^${{ steps.meta.outputs.tag }}$" | head -1 || echo "")
+          RANGE="$REF"
+          [ -n "$PREV" ] && RANGE="${PREV}..${REF}"
           COMMITS=$(git log --no-merges --oneline "$RANGE" -- vaidcord-go | wc -l | tr -d ' ')
           ARGS=()
           if [ -f vaidcord-go/.release-highlights ]; then
@@ -123,7 +134,7 @@ jobs:
           fi
           python3 .github/scripts/release_notes.py \
             --package vaidcord-go --version "${{ steps.meta.outputs.version }}" \
-            --tag "${{ steps.meta.outputs.tag }}" --language go \
+            --tag "${{ steps.ref.outputs.ref }}" --language go \
             --tag-pattern "vaidcord-go/v*" --path vaidcord-go --path UNITED.md \
             --card-url "${{ steps.card.outputs.card-url }}" \
             "${ARGS[@]}" \
@@ -138,9 +149,10 @@ jobs:
             gh release edit "$TAG" --title "VAIDCORD-GO ${{ steps.meta.outputs.version }}" --notes-file release-notes.md
             gh release upload "$TAG" release-card.svg --clobber
           else
+            # --target creates the tag when it does not exist yet (dispatch mode).
             gh release create "$TAG" release-card.svg \
               --title "VAIDCORD-GO ${{ steps.meta.outputs.version }}" \
-              --notes-file release-notes.md --verify-tag
+              --notes-file release-notes.md --target "${GITHUB_SHA}"
           fi
 
       - name: Request Go module proxy indexing

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -143,7 +143,16 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           for attempt in 1 2 3 4 5; do
-            if cargo publish; then
+            set +e
+            OUTPUT=$(cargo publish 2>&1)
+            STATUS=$?
+            set -e
+            echo "$OUTPUT"
+            if [ $STATUS -eq 0 ]; then
+              exit 0
+            fi
+            if echo "$OUTPUT" | grep -qi "already exists\|already uploaded"; then
+              echo "vaidcord ${{ steps.meta.outputs.version }} is already on crates.io; continuing."
               exit 0
             fi
             echo "publish failed (attempt ${attempt}); retrying in 30s..."
@@ -152,12 +161,24 @@ jobs:
           echo "cargo publish failed after retries" >&2
           exit 1
 
+      - name: Resolve git reference for history
+        id: ref
+        working-directory: .
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "ref=${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate release card
         working-directory: .
         run: |
-          PREV=$(git tag --list 'rust-v*' --sort=-creatordate --merged '${{ steps.meta.outputs.tag }}^' | grep -v "^${{ steps.meta.outputs.tag }}$" | head -1 || echo "")
-          RANGE="${{ steps.meta.outputs.tag }}"
-          [ -n "$PREV" ] && RANGE="${PREV}..${{ steps.meta.outputs.tag }}"
+          REF='${{ steps.ref.outputs.ref }}'
+          PREV=$(git tag --list 'rust-v*' --sort=-creatordate --merged "${REF}^" 2>/dev/null | grep -v "^${{ steps.meta.outputs.tag }}$" | head -1 || echo "")
+          RANGE="$REF"
+          [ -n "$PREV" ] && RANGE="${PREV}..${REF}"
           COMMITS=$(git log --no-merges --oneline "$RANGE" -- vaidcord-rust | wc -l | tr -d ' ')
           ARGS=()
           if [ -f vaidcord-rust/.release-highlights ]; then
@@ -191,7 +212,7 @@ jobs:
           fi
           python3 .github/scripts/release_notes.py \
             --package vaidcord-rust --version "${{ steps.meta.outputs.version }}" \
-            --tag "${{ steps.meta.outputs.tag }}" --language rust \
+            --tag "${{ steps.ref.outputs.ref }}" --language rust \
             --tag-pattern "rust-v*" --path vaidcord-rust --path UNITED.md \
             --card-url "${{ steps.card.outputs.card-url }}" \
             "${ARGS[@]}" \
@@ -207,7 +228,8 @@ jobs:
             gh release edit "$TAG" --title "VAIDCORD-RUST ${{ steps.meta.outputs.version }}" --notes-file release-notes.md
             gh release upload "$TAG" release-card.svg --clobber
           else
+            # --target creates the tag when it does not exist yet (dispatch mode).
             gh release create "$TAG" release-card.svg \
               --title "VAIDCORD-RUST ${{ steps.meta.outputs.version }}" \
-              --notes-file release-notes.md --verify-tag
+              --notes-file release-notes.md --target "${GITHUB_SHA}"
           fi


### PR DESCRIPTION
Небольшая доводка релизных workflow после #35:

- при запуске через `workflow_dispatch` тег ещё не существует — карточка и release notes теперь строятся от текущего коммита (`Resolve git reference` шаг), а `gh release create --target` сам создаёт тег;
- публикация стала идемпотентной: `skip-existing` для PyPI и допуск «already exists» для crates.io — повторный запуск по push-событию созданного тега проходит как no-op вместо падения.

Это позволяет выпускать релизы кнопкой/через API без предварительного пуша тегов.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUfVbkhruiD2PaneDK5J6k)_